### PR TITLE
Update GTest to v1.12.0 to fix build with gcc11.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "third_party/googletest/googletest"]
 	path = third_party/googletest/googletest
 	url = https://github.com/google/googletest.git
-	branch = v1.8.x


### PR DESCRIPTION
Update GTest to v1.12.0 to fix build with GCC11. 
#18 