### PR TITLE
fix: clone the id chunk before pickle dump to avoid dumping the entire tensor

### DIFF
--- a/graphlearn_torch/python/partition/base.py
+++ b/graphlearn_torch/python/partition/base.py
@@ -349,8 +349,8 @@ class PartitionerBase(ABC):
       n_ids_chunks = torch.chunk(n_ids, chunks=((n_ids.shape[0] + self.chunk_size - 1) // self.chunk_size))
       for chunk in n_ids_chunks:
         p_node_feat_chunk = FeaturePartitionData(
-          feats=node_feat[chunk], 
-          ids=chunk,
+          feats=node_feat[chunk],
+          ids=chunk.clone(),
           cache_feats=None,
           cache_ids=None
         )
@@ -373,7 +373,7 @@ class PartitionerBase(ABC):
       for chunk in eids_chunks:
         p_edge_feat_chunk = FeaturePartitionData(
           feats=edge_feat[chunk],
-          ids=chunk,
+          ids=chunk.clone(),
           cache_feats=None,
           cache_ids=None
         )


### PR DESCRIPTION
Dumping a chunk of a tensor using pickle will dump the entire tensor into the file, as chunk is just a view of the original tensor. In this PR we copy the chunk (we only chunk id tensors thus the copy cost is not very large) before the pickle dump.