### PR TITLE
Fix igbh rgnn example

### DIFF
--- a/examples/igbh/rgnn.py
+++ b/examples/igbh/rgnn.py
@@ -57,6 +57,11 @@ class RGNN(torch.nn.Module):
 
   def forward(self, x_dict, edge_index_dict):
     for i, conv in enumerate(self.convs):
+      
+      for key in list(edge_index_dict.keys()):
+        if key[0] not in x_dict or key[-1] not in x_dict:
+          del edge_index_dict[key]
+          
       x_dict = conv(x_dict, edge_index_dict)
       if i != len(self.convs) - 1:
         x_dict = {key: F.leaky_relu(x) for key, x in x_dict.items()}

--- a/examples/igbh/train_rgnn.py
+++ b/examples/igbh/train_rgnn.py
@@ -139,6 +139,7 @@ if __name__ == '__main__':
   parser.add_argument('--log_every', type=int, default=5)
   parser.add_argument("--cpu_mode", action="store_true",
       help="Only use CPU for sampling and training, default is False.")
+  parser.add_argument("--edge_dir", type=str, default='in')
   args = parser.parse_args()
   args.with_gpu = (not args.cpu_mode) and torch.cuda.is_available()
   device = torch.device('cuda' if args.with_gpu else 'cpu')
@@ -146,7 +147,7 @@ if __name__ == '__main__':
   igbh_dataset = IGBHeteroDataset(args.path, args.dataset_size, args.in_memory,
                                   args.num_classes==2983)
   # init graphlearn_torch Dataset.
-  glt_dataset = glt.data.Dataset(edge_dir='in')
+  glt_dataset = glt.data.Dataset(edge_dir=args.edge_dir)
   glt_dataset.init_graph(
     edge_index=igbh_dataset.edge_dict,
     graph_mode='ZERO_COPY' if args.with_gpu else 'CPU'


### PR DESCRIPTION
The RGAT heterogeneous model created in the current rgnn.py is convolved according to the **edge node type** in the graph. However, the actual **node types** used may be inconsistent, which may lead to errors(key error in dict). So filtering was performed before convolution.