### PR TITLE
[Example] Separate server and client launch scripts for server-client mode distributed training

### DIFF
--- a/docs/get_started/dist_train.md
+++ b/docs/get_started/dist_train.md
@@ -188,4 +188,4 @@ CUDA_VISIBLE_DEVICES=2,3 python dist_train_sage_supervised.py \
 ```
 
 The complete code of the above example can be found in `examples/distributed/dist_train_sage_supervised.py`.
-An example of distributed training in server-client mode can be found in `examples/distributed/dist_train_sage_supervised_with_server.py`.
+An example of distributed training in server-client mode can be found in `examples/distributed/server_client_mode`.

--- a/docs/tutorial/dist.md
+++ b/docs/tutorial/dist.md
@@ -667,4 +667,4 @@ a distributed dataset when creating the `DistNeighborLoader`, as all dataset
 partitions are managed by server nodes.
 
 The complete example of distributed training in the server-client mode can be
-found [here](https://github.com/alibaba/graphlearn-for-pytorch/blob/main/examples/distributed/dist_train_sage_supervised_with_server.py)
+found [here](https://github.com/alibaba/graphlearn-for-pytorch/blob/main/examples/distributed/server_client_mode)

--- a/examples/distributed/README.md
+++ b/examples/distributed/README.md
@@ -120,28 +120,28 @@ python partition_ogbn_dataset.py --dataset=ogbn-products --num_server_partitions
 - 3 client nodes each with 2 client processes for training and 2 GPUs.
 ```
 # server node 0:
-CUDA_VISIBLE_DEVICES=0,1 python dist_train_sage_supervised_with_server.py \
-  --num_server_nodes=2 --num_client_nodes=3 --role=server --node_rank=0 \
+CUDA_VISIBLE_DEVICES=0,1 python server_client_mode/sage_supervised_server.py \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=0 --num_server_dataset_partitions=2 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 
 # server node 1:
-CUDA_VISIBLE_DEVICES=2,3 python dist_train_sage_supervised_with_server.py \
-  --num_server_nodes=2 --num_client_nodes=3 --role=server --node_rank=1 \
+CUDA_VISIBLE_DEVICES=2,3 python server_client_mode/sage_supervised_server.py \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=1 --num_server_dataset_partitions=2 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 
 # client node 0:
-CUDA_VISIBLE_DEVICES=4,5 python dist_train_sage_supervised_with_server.py \
-  --num_server_nodes=2 --num_client_nodes=3 --role=client --node_rank=0 \
+CUDA_VISIBLE_DEVICES=4,5 python server_client_mode/sage_supervised_client.py \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=0 --num_client_dataset_partitions=3 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 
 # client node 1:
-CUDA_VISIBLE_DEVICES=6,7 python dist_train_sage_supervised_with_server.py \
-  --num_server_nodes=2 --num_client_nodes=3 --role=client --node_rank=1 \
+CUDA_VISIBLE_DEVICES=6,7 python server_client_mode/sage_supervised_client.py \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=1 --num_client_dataset_partitions=3 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 
 # client node 2:
-CUDA_VISIBLE_DEVICES=8,9 python dist_train_sage_supervised_with_server.py \
-  --num_server_nodes=2 --num_client_nodes=3 --role=client --node_rank=2 \
+CUDA_VISIBLE_DEVICES=8,9 python server_client_mode/sage_supervised_client.py \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=2 --num_client_dataset_partitions=3 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 ```
 

--- a/examples/distributed/server_client_mode/sage_supervised_server.py
+++ b/examples/distributed/server_client_mode/sage_supervised_server.py
@@ -1,0 +1,150 @@
+# Copyright 2022 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import argparse
+import os.path as osp
+
+import graphlearn_torch as glt
+import torch
+import torch.distributed
+
+
+def run_server_proc(num_servers: int, num_clients: int, server_rank: int,
+                    dataset: glt.distributed.DistDataset, master_addr: str,
+                    server_client_port: int):
+  print(f'-- [Server {server_rank}] Initializing server ...')
+  glt.distributed.init_server(
+    num_servers=num_servers,
+    num_clients=num_clients,
+    server_rank=server_rank,
+    dataset=dataset,
+    master_addr=master_addr,
+    master_port=server_client_port,
+    num_rpc_threads=16,
+    server_group_name='dist-train-supervised-sage-server')
+
+  print(f'-- [Server {server_rank}] Waiting for exit ...')
+  glt.distributed.wait_and_shutdown_server()
+
+  print(f'-- [Server {server_rank}] Exited ...')
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(
+    description="Arguments for distributed training of supervised SAGE with servers.")
+  parser.add_argument(
+    "--dataset",
+    type=str,
+    default='ogbn-products',
+    help="The name of ogbn dataset.",
+  )
+  parser.add_argument(
+    "--dataset_root_dir",
+    type=str,
+    default='../../data/products',
+    help="The root directory (relative path) of partitioned ogbn dataset.",
+  )
+  parser.add_argument(
+    "--num_server_dataset_partitions",
+    type=int,
+    default=2,
+    help="The number of server partitions of the dataset.",
+  )
+  parser.add_argument(
+    "--num_server_nodes",
+    type=int,
+    default=2,
+    help="Number of server nodes for remote sampling.",
+  )
+  parser.add_argument(
+    "--num_client_nodes",
+    type=int,
+    default=2,
+    help="Number of client nodes for training.",
+  )
+  parser.add_argument(
+    "--node_rank",
+    type=int,
+    default=0,
+    help="The node rank of the current role.",
+  )
+  parser.add_argument(
+    "--num_server_procs_per_node",
+    type=int,
+    default=1,
+    help="The number of server processes for remote sampling per server node.",
+  )
+  parser.add_argument(
+    "--num_client_procs_per_node",
+    type=int,
+    default=2,
+    help="The number of client processes for training per client node.",
+  )
+  parser.add_argument(
+    "--master_addr",
+    type=str,
+    default='localhost',
+    help="The master address for RPC initialization.",
+  )
+  parser.add_argument(
+    "--server_client_master_port",
+    type=int,
+    default=11110,
+    help="The port used for RPC initialization across all servers and clients.",
+  )
+  args = parser.parse_args()
+
+  print(
+    f'--- Distributed training example of supervised SAGE with server-client mode. Server {args.node_rank} ---'
+  )
+  print(f'* dataset: {args.dataset}')
+  print(f'* dataset root dir: {args.dataset_root_dir}')
+  print(f'* total server nodes: {args.num_server_nodes}')
+  print(f'* node rank: {args.node_rank}')
+  print(f'* number of server processes per server node: {args.num_server_procs_per_node}')
+  print(f'* number of client processes per client node: {args.num_client_procs_per_node}')
+  print(f'* master addr: {args.master_addr}')
+  print(f'* server-client master port: {args.server_client_master_port}')
+
+  print(f'* number of server dataset partitions: {args.num_server_dataset_partitions}')
+
+  num_servers = args.num_server_nodes * args.num_server_procs_per_node
+  num_clients = args.num_client_nodes * args.num_client_procs_per_node
+  root_dir = osp.join(osp.dirname(osp.realpath(__file__)), args.dataset_root_dir)
+  data_pidx = args.node_rank % args.num_server_dataset_partitions
+
+  mp_context = torch.multiprocessing.get_context('spawn')
+
+  print('--- Loading data partition ...')
+  dataset = glt.distributed.DistDataset()
+  dataset.load(
+    root_dir=osp.join(root_dir, f'{args.dataset}-partitions'),
+    partition_idx=data_pidx,
+    graph_mode='ZERO_COPY',
+    whole_node_label_file=osp.join(root_dir, f'{args.dataset}-label', 'label.pt'))
+
+  print('--- Launching server processes ...')
+  server_procs = []
+  for local_proc_rank in range(args.num_server_procs_per_node):
+    server_rank = args.node_rank * args.num_server_procs_per_node + local_proc_rank
+    sproc = mp_context.Process(
+      target=run_server_proc,
+      args=(num_servers, num_clients, server_rank, dataset, args.master_addr,
+            args.server_client_master_port))
+    server_procs.append(sproc)
+  for sproc in server_procs:
+    sproc.start()
+  for sproc in server_procs:
+    sproc.join()


### PR DESCRIPTION
Separate the server and client launch scripts to have a better view of the parameters used for each role respectively and prepare for the next steps of further decoupling the launching and shutdown procedures of the server and client.

