### PR TITLE
[Feat] put input data on server and allow for n to n connection between servers and clients

### DIFF
--- a/examples/distributed/README.md
+++ b/examples/distributed/README.md
@@ -110,10 +110,7 @@ in an environment consisting of 2 nodes, each with 2 A100 GPUs.
 
 ## Example of distributed training with server-client mode
 The server-client mode enables the training to be decoupled, allowing for an arbitrary number of servers or clients. However, it's important to note that the number of clients must be equal to or greater than the number of servers, because each server needs at least one client to initiate it.
-### Prepare data with different number of servers and clients.
-Here we use ogbn_products and partition it into 2 server parts and 3 client parts.
-```
-python partition_ogbn_dataset.py --dataset=ogbn-products --num_server_partitions=2 --num_client_partitions=3
+
 ```
 ### Launch training with:
 - 2 server nodes each with 1 server process for remote sampling and 2 GPUs.
@@ -121,27 +118,27 @@ python partition_ogbn_dataset.py --dataset=ogbn-products --num_server_partitions
 ```
 # server node 0:
 CUDA_VISIBLE_DEVICES=0,1 python server_client_mode/sage_supervised_server.py \
-  --num_server_nodes=2 --num_client_nodes=3 --node_rank=0 --num_server_dataset_partitions=2 \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=0 --num_dataset_partitions=2 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 
 # server node 1:
 CUDA_VISIBLE_DEVICES=2,3 python server_client_mode/sage_supervised_server.py \
-  --num_server_nodes=2 --num_client_nodes=3 --node_rank=1 --num_server_dataset_partitions=2 \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=1 --num_dataset_partitions=2 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 
 # client node 0:
 CUDA_VISIBLE_DEVICES=4,5 python server_client_mode/sage_supervised_client.py \
-  --num_server_nodes=2 --num_client_nodes=3 --node_rank=0 --num_client_dataset_partitions=3 \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=0 --num_dataset_partitions=3 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 
 # client node 1:
 CUDA_VISIBLE_DEVICES=6,7 python server_client_mode/sage_supervised_client.py \
-  --num_server_nodes=2 --num_client_nodes=3 --node_rank=1 --num_client_dataset_partitions=3 \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=1 --num_dataset_partitions=3 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 
 # client node 2:
 CUDA_VISIBLE_DEVICES=8,9 python server_client_mode/sage_supervised_client.py \
-  --num_server_nodes=2 --num_client_nodes=3 --node_rank=2 --num_client_dataset_partitions=3 \
+  --num_server_nodes=2 --num_client_nodes=3 --node_rank=2 --num_dataset_partitions=3 \
   --num_server_procs_per_node=1 --num_client_procs_per_node=2 --master_addr=localhost
 ```
 

--- a/examples/distributed/server_client_mode/sage_supervised_client.py
+++ b/examples/distributed/server_client_mode/sage_supervised_client.py
@@ -25,6 +25,8 @@ import torch.nn.functional as F
 from ogb.nodeproppred import Evaluator
 from torch.nn.parallel import DistributedDataParallel
 from torch_geometric.nn import GraphSAGE
+from typing import List
+from torch.distributed.algorithms.join import Join
 
 
 @torch.no_grad()
@@ -36,10 +38,11 @@ def test(model, test_loader, dataset_name):
   for i, batch in enumerate(test_loader):
     if i == 0:
       device = batch.x.device
-    x = model(batch.x, batch.edge_index)[:batch.batch_size]
+    x = model.module(batch.x, batch.edge_index)[:batch.batch_size]
     xs.append(x.cpu())
     y_true.append(batch.y[:batch.batch_size].cpu())
     del batch
+
   xs = [t.to(device) for t in xs]
   y_true = [t.to(device) for t in y_true]
   y_pred = torch.cat(xs, dim=0).argmax(dim=-1, keepdim=True)
@@ -51,10 +54,13 @@ def test(model, test_loader, dataset_name):
   return test_acc
 
 
-def run_client_proc(num_servers: int, num_clients: int, client_rank: int, dataset_name: str,
-                    train_idx: torch.Tensor, test_idx: torch.Tensor, epochs: int, batch_size: int,
-                    master_addr: str, server_client_port: int, training_pg_master_port: int,
-                    train_loader_master_port: int, test_loader_master_port: int):
+def run_client_proc(
+  num_servers: int, num_clients: int, client_rank: int, server_rank: List[int],
+  dataset_name: str, train_path: List[str], test_path: List[str], epochs: int,
+  batch_size: int, master_addr: str, server_client_port: int,
+  training_pg_master_port: int, train_loader_master_port: int,
+  test_loader_master_port: int
+):
   print(f'-- [Client {client_rank}] Initializing client ...')
   glt.distributed.init_client(
     num_servers=num_servers,
@@ -63,64 +69,74 @@ def run_client_proc(num_servers: int, num_clients: int, client_rank: int, datase
     master_addr=master_addr,
     master_port=server_client_port,
     num_rpc_threads=4,
-    client_group_name='dist-train-supervised-sage-client')
+    client_group_name='dist-train-supervised-sage-client'
+  )
 
+  # Initialize training process group of PyTorch.
   current_ctx = glt.distributed.get_context()
   current_device = torch.device(current_ctx.rank % torch.cuda.device_count())
 
-  # Initialize training process group of PyTorch.
-  print(f'-- [Client {client_rank}] Initializing training process group of PyTorch ...')
+  print(
+    f'-- [Client {client_rank}] Initializing training process group of PyTorch ...'
+  )
   torch.distributed.init_process_group(
     backend='nccl',
     rank=current_ctx.rank,
     world_size=current_ctx.world_size,
-    init_method='tcp://{}:{}'.format(master_addr, training_pg_master_port))
+    init_method='tcp://{}:{}'.format(master_addr, training_pg_master_port)
+  )
 
-  # Select target server on remote.
-  target_server_rank = client_rank % num_servers
-  # Fetch availble device count on the target server.
-  target_server_device_count = glt.distributed.request_server(
-    target_server_rank, func=torch.cuda.device_count)
-
+  server_device_count = glt.distributed.request_server(
+    server_rank=server_rank[0], func=torch.cuda.device_count)
   # Create distributed neighbor loader on remote server for training.
   print(f'-- [Client {client_rank}] Creating training dataloader ...')
   train_loader = glt.distributed.DistNeighborLoader(
     data=None,
     num_neighbors=[15, 10, 5],
-    input_nodes=train_idx,
+    input_nodes=train_path,
     batch_size=batch_size,
     shuffle=True,
     collect_features=True,
     to_device=current_device,
     worker_options=glt.distributed.RemoteDistSamplingWorkerOptions(
-      server_rank=target_server_rank,
+      server_rank=server_rank,
       num_workers=2,
-      worker_devices=[torch.device('cuda', i % target_server_device_count) for i in range(2)],
+      worker_devices=[
+        torch.device(f'cuda:{i}') for i in range(server_device_count)
+      ],
       worker_concurrency=4,
       master_addr=master_addr,
       master_port=train_loader_master_port,
       buffer_size='1GB',
-      prefetch_size=2))
+      prefetch_size=2,
+      worker_key='train'
+    )
+  )
 
   # Create distributed neighbor loader on remote server for testing.
   print(f'-- [Client {client_rank}] Creating testing dataloader ...')
   test_loader = glt.distributed.DistNeighborLoader(
     data=None,
-    num_neighbors=[15, 10, 5],
-    input_nodes=test_idx,
+    num_neighbors=[2, 2, 2],
+    input_nodes=test_path,
     batch_size=batch_size,
     shuffle=False,
     collect_features=True,
     to_device=current_device,
     worker_options=glt.distributed.RemoteDistSamplingWorkerOptions(
-      server_rank=target_server_rank,
+      server_rank=server_rank,
       num_workers=2,
-      worker_devices=[torch.device('cuda', i % target_server_device_count) for i in range(2)],
+      worker_devices=[
+        torch.device(f'cuda:{i}') for i in range(server_device_count)
+      ],
       worker_concurrency=4,
       master_addr=master_addr,
       master_port=test_loader_master_port,
-      buffer_size='2GB',
-      prefetch_size=4))
+      buffer_size='1GB',
+      prefetch_size=2,
+      worker_key='test'
+    )
+  )
 
   # Define model and optimizer.
   print(f'-- [Client {client_rank}] Initializing model and optimizer ...')
@@ -139,15 +155,20 @@ def run_client_proc(num_servers: int, num_clients: int, client_rank: int, datase
   for epoch in range(0, epochs):
     model.train()
     start = time.time()
-    for batch in train_loader:
-      optimizer.zero_grad()
-      out = model(batch.x, batch.edge_index)[:batch.batch_size].log_softmax(dim=-1)
-      loss = F.nll_loss(out, batch.y[:batch.batch_size])
-      loss.backward()
-      optimizer.step()
+
+    with Join([model]):
+      for batch in train_loader:
+        optimizer.zero_grad()
+        out = model(batch.x,
+                    batch.edge_index)[:batch.batch_size].log_softmax(dim=-1)
+        loss = F.nll_loss(out, batch.y[:batch.batch_size])
+        loss.backward()
+        optimizer.step()
+
     end = time.time()
     print(
-      f'-- [Client {client_rank}] Epoch: {epoch:03d}, Loss: {loss:.4f}, Epoch Time: {end - start}')
+      f'-- [Client {client_rank}] Epoch: {epoch:03d}, Loss: {loss:.4f}, Epoch Time: {end - start}'
+    )
     torch.cuda.synchronize()
     torch.distributed.barrier()
     # Test accuracy.
@@ -165,7 +186,8 @@ def run_client_proc(num_servers: int, num_clients: int, client_rank: int, datase
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(
-    description="Arguments for distributed training of supervised SAGE with servers.")
+    description="Arguments for distributed training of supervised SAGE with servers."
+  )
   parser.add_argument(
     "--dataset",
     type=str,
@@ -179,10 +201,10 @@ if __name__ == '__main__':
     help="The root directory (relative path) of partitioned ogbn dataset.",
   )
   parser.add_argument(
-    "--num_client_dataset_partitions",
+    "--num_dataset_partitions",
     type=int,
-    default=3,
-    help="The number of client partitions of the dataset.",
+    default=2,
+    help="The number of partitions of the dataset.",
   )
   parser.add_argument(
     "--num_server_nodes",
@@ -266,19 +288,21 @@ if __name__ == '__main__':
   print(f'* total server nodes: {args.num_server_nodes}')
   print(f'* total client nodes: {args.num_client_nodes}')
   print(f'* node rank: {args.node_rank}')
-  print(f'* number of server processes per server node: {args.num_server_procs_per_node}')
-  print(f'* number of client processes per client node: {args.num_client_procs_per_node}')
+  print(
+    f'* number of server processes per server node: {args.num_server_procs_per_node}'
+  )
+  print(
+    f'* number of client processes per client node: {args.num_client_procs_per_node}'
+  )
   print(f'* master addr: {args.master_addr}')
   print(f'* server-client master port: {args.server_client_master_port}')
-
-  print(f'* number of client dataset partitions: {args.num_client_dataset_partitions}')
+  print(f'* number of dataset partitions: {args.num_dataset_partitions}')
 
   num_servers = args.num_server_nodes * args.num_server_procs_per_node
   num_clients = args.num_client_nodes * args.num_client_procs_per_node
-  root_dir = osp.join(osp.dirname(osp.realpath(__file__)), args.dataset_root_dir)
-  data_pidx = args.node_rank % args.num_client_dataset_partitions
-
-  mp_context = torch.multiprocessing.get_context('spawn')
+  root_dir = osp.join(
+    osp.dirname(osp.realpath(__file__)), args.dataset_root_dir
+  )
 
   print(f'* epochs: {args.epochs}')
   print(f'* batch size: {args.batch_size}')
@@ -287,23 +311,38 @@ if __name__ == '__main__':
   print(f'* testing loader master port: {args.test_loader_master_port}')
 
   print('--- Loading training and testing seeds ...')
-  train_idx = torch.load(
-    osp.join(root_dir, f'{args.dataset}-train-partitions', f'partition{data_pidx}.pt'))
-  test_idx = torch.load(
-    osp.join(root_dir, f'{args.dataset}-test-partitions', f'partition{data_pidx}.pt'))
-  train_idx = train_idx.split(train_idx.size(0) // args.num_client_procs_per_node)
-  test_idx = test_idx.split(test_idx.size(0) // args.num_client_procs_per_node)
+  train_path_list = []
+  for data_pidx in range(args.num_dataset_partitions):
+    train_path_list.append(
+      osp.join(
+        root_dir, f'{args.dataset}-train-partitions', f'partition{data_pidx}.pt'
+      )
+    )
+
+  test_path_list = []
+  for data_pidx in range(args.num_dataset_partitions):
+    test_path_list.append(
+      osp.join(
+        root_dir, f'{args.dataset}-test-partitions', f'partition{data_pidx}.pt'
+      )
+    )
 
   print('--- Launching client processes ...')
+  mp_context = torch.multiprocessing.get_context('spawn')
   client_procs = []
   for local_proc_rank in range(args.num_client_procs_per_node):
     client_rank = args.node_rank * args.num_client_procs_per_node + local_proc_rank
     cproc = mp_context.Process(
       target=run_client_proc,
-      args=(num_servers, num_clients, client_rank, args.dataset, train_idx[local_proc_rank],
-            test_idx[local_proc_rank], args.epochs, args.batch_size, args.master_addr,
-            args.server_client_master_port, args.training_pg_master_port,
-            args.train_loader_master_port, args.test_loader_master_port))
+      args=(
+        num_servers, num_clients, client_rank,
+        [server_rank for server_rank in range(num_servers)
+        ], args.dataset, train_path_list, test_path_list, args.epochs,
+        args.batch_size, args.master_addr, args.server_client_master_port,
+        args.training_pg_master_port, args.train_loader_master_port,
+        args.test_loader_master_port
+      )
+    )
     client_procs.append(cproc)
   for cproc in client_procs:
     cproc.start()

--- a/examples/distributed/server_client_mode/sage_supervised_client.py
+++ b/examples/distributed/server_client_mode/sage_supervised_client.py
@@ -117,7 +117,7 @@ def run_client_proc(
   print(f'-- [Client {client_rank}] Creating testing dataloader ...')
   test_loader = glt.distributed.DistNeighborLoader(
     data=None,
-    num_neighbors=[2, 2, 2],
+    num_neighbors=[15, 10, 5],
     input_nodes=test_path,
     batch_size=batch_size,
     shuffle=False,

--- a/examples/distributed/server_client_mode/sage_supervised_server.py
+++ b/examples/distributed/server_client_mode/sage_supervised_server.py
@@ -21,9 +21,11 @@ import torch
 import torch.distributed
 
 
-def run_server_proc(num_servers: int, num_clients: int, server_rank: int,
-                    dataset: glt.distributed.DistDataset, master_addr: str,
-                    server_client_port: int):
+def run_server_proc(
+  num_servers: int, num_clients: int, server_rank: int,
+  dataset: glt.distributed.DistDataset, master_addr: str,
+  server_client_port: int
+):
   print(f'-- [Server {server_rank}] Initializing server ...')
   glt.distributed.init_server(
     num_servers=num_servers,
@@ -33,7 +35,8 @@ def run_server_proc(num_servers: int, num_clients: int, server_rank: int,
     master_addr=master_addr,
     master_port=server_client_port,
     num_rpc_threads=16,
-    server_group_name='dist-train-supervised-sage-server')
+    server_group_name='dist-train-supervised-sage-server'
+  )
 
   print(f'-- [Server {server_rank}] Waiting for exit ...')
   glt.distributed.wait_and_shutdown_server()
@@ -43,7 +46,8 @@ def run_server_proc(num_servers: int, num_clients: int, server_rank: int,
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(
-    description="Arguments for distributed training of supervised SAGE with servers.")
+    description="Arguments for distributed training of supervised SAGE with servers."
+  )
   parser.add_argument(
     "--dataset",
     type=str,
@@ -57,10 +61,10 @@ if __name__ == '__main__':
     help="The root directory (relative path) of partitioned ogbn dataset.",
   )
   parser.add_argument(
-    "--num_server_dataset_partitions",
+    "--num_dataset_partitions",
     type=int,
     default=2,
-    help="The number of server partitions of the dataset.",
+    help="The number of partitions of the dataset.",
   )
   parser.add_argument(
     "--num_server_nodes",
@@ -113,17 +117,23 @@ if __name__ == '__main__':
   print(f'* dataset root dir: {args.dataset_root_dir}')
   print(f'* total server nodes: {args.num_server_nodes}')
   print(f'* node rank: {args.node_rank}')
-  print(f'* number of server processes per server node: {args.num_server_procs_per_node}')
-  print(f'* number of client processes per client node: {args.num_client_procs_per_node}')
+  print(
+    f'* number of server processes per server node: {args.num_server_procs_per_node}'
+  )
+  print(
+    f'* number of client processes per client node: {args.num_client_procs_per_node}'
+  )
   print(f'* master addr: {args.master_addr}')
   print(f'* server-client master port: {args.server_client_master_port}')
 
-  print(f'* number of server dataset partitions: {args.num_server_dataset_partitions}')
+  print(f'* number of dataset partitions: {args.num_dataset_partitions}')
 
   num_servers = args.num_server_nodes * args.num_server_procs_per_node
   num_clients = args.num_client_nodes * args.num_client_procs_per_node
-  root_dir = osp.join(osp.dirname(osp.realpath(__file__)), args.dataset_root_dir)
-  data_pidx = args.node_rank % args.num_server_dataset_partitions
+  root_dir = osp.join(
+    osp.dirname(osp.realpath(__file__)), args.dataset_root_dir
+  )
+  data_pidx = args.node_rank % args.num_dataset_partitions
 
   mp_context = torch.multiprocessing.get_context('spawn')
 
@@ -133,7 +143,10 @@ if __name__ == '__main__':
     root_dir=osp.join(root_dir, f'{args.dataset}-partitions'),
     partition_idx=data_pidx,
     graph_mode='ZERO_COPY',
-    whole_node_label_file=osp.join(root_dir, f'{args.dataset}-label', 'label.pt'))
+    whole_node_label_file=osp.join(
+      root_dir, f'{args.dataset}-label', 'label.pt'
+    )
+  )
 
   print('--- Launching server processes ...')
   server_procs = []
@@ -141,8 +154,11 @@ if __name__ == '__main__':
     server_rank = args.node_rank * args.num_server_procs_per_node + local_proc_rank
     sproc = mp_context.Process(
       target=run_server_proc,
-      args=(num_servers, num_clients, server_rank, dataset, args.master_addr,
-            args.server_client_master_port))
+      args=(
+        num_servers, num_clients, server_rank, dataset, args.master_addr,
+        args.server_client_master_port
+      )
+    )
     server_procs.append(sproc)
   for sproc in server_procs:
     sproc.start()

--- a/graphlearn_torch/csrc/sample_queue.cc
+++ b/graphlearn_torch/csrc/sample_queue.cc
@@ -24,9 +24,13 @@ void SampleQueue::Enqueue(const TensorMap& msg) {
   });
 }
 
-TensorMap SampleQueue::Dequeue() {
-  auto shm_data = shmq_->Dequeue();
+TensorMap SampleQueue::Dequeue(unsigned int timeout_ms) {
+  auto shm_data = shmq_->Dequeue(timeout_ms);
   return TensorMapSerializer::Load(std::move(shm_data));
+}
+
+bool SampleQueue::Empty() {
+  return shmq_->Empty();
 }
 
 }  // namespace graphlearn_torch

--- a/graphlearn_torch/include/sample_queue.h
+++ b/graphlearn_torch/include/sample_queue.h
@@ -42,7 +42,8 @@ public:
   }
 
   void Enqueue(const TensorMap& msg);
-  TensorMap Dequeue();
+  TensorMap Dequeue(unsigned int timeout_ms);
+  bool Empty();
 
 private:
   std::unique_ptr<ShmQueue> shmq_;

--- a/graphlearn_torch/include/sample_queue.h
+++ b/graphlearn_torch/include/sample_queue.h
@@ -42,7 +42,7 @@ public:
   }
 
   void Enqueue(const TensorMap& msg);
-  TensorMap Dequeue(unsigned int timeout_ms);
+  TensorMap Dequeue(unsigned int timeout_ms = 0);
   bool Empty();
 
 private:

--- a/graphlearn_torch/include/shm_queue.h
+++ b/graphlearn_torch/include/shm_queue.h
@@ -205,7 +205,9 @@ public:
 
   /// Dequeue a message on child process.
   /// \return `ShmData`
-  ShmData Dequeue();
+  ShmData Dequeue(unsigned int timeout_ms);
+
+  bool Empty();
 
   /// Pin memory on child processes.
   void PinMemory();
@@ -233,6 +235,11 @@ private:
     void operator()(ShmQueueMeta* meta_ptr);
   };
   std::shared_ptr<ShmQueueMeta> meta_;
+};
+
+class QueueTimeoutError : public std::runtime_error {
+public:
+    QueueTimeoutError() : std::runtime_error("Timeout: Queue is empty.") {}
 };
 
 }  // namespace graphlearn_torch

--- a/graphlearn_torch/include/shm_queue.h
+++ b/graphlearn_torch/include/shm_queue.h
@@ -205,7 +205,7 @@ public:
 
   /// Dequeue a message on child process.
   /// \return `ShmData`
-  ShmData Dequeue(unsigned int timeout_ms);
+  ShmData Dequeue(unsigned int timeout_ms = 0);
 
   bool Empty();
 

--- a/graphlearn_torch/python/channel/__init__.py
+++ b/graphlearn_torch/python/channel/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from .base import SampleMessage, ChannelBase
+from .base import SampleMessage, ChannelBase, QueueTimeoutError
 from .mp_channel import MpChannel
 from .shm_channel import ShmChannel
 from .remote_channel import RemoteReceivingChannel

--- a/graphlearn_torch/python/channel/base.py
+++ b/graphlearn_torch/python/channel/base.py
@@ -15,9 +15,10 @@
 
 from abc import ABC, abstractmethod
 from typing import Dict
-
 import torch
+from .. import py_graphlearn_torch as pywrap
 
+QueueTimeoutError =  pywrap.QueueTimeoutError
 
 # A `SampleMessage` contains all possible results from a sampler, including
 # subgraph data, features and user defined metas.

--- a/graphlearn_torch/python/channel/remote_channel.py
+++ b/graphlearn_torch/python/channel/remote_channel.py
@@ -18,6 +18,7 @@ import queue
 import torch
 
 from .base import SampleMessage, ChannelBase
+from typing import Union, List
 
 
 class RemoteReceivingChannel(ChannelBase):
@@ -25,24 +26,35 @@ class RemoteReceivingChannel(ChannelBase):
   from remote sampling servers.
 
   Args:
-    server_rank (int): The rank of target server to fetch sampled messages.
-    producer_id (int): The sequence id of created sampling producer on the
-      target server.
-    num_expected (int): The number of expected sampled messages at one epoch.
-    prefetch_size (int): The number of messages to prefetch. (Default ``4``).
+    server_rank (int or List[int]): The ranks of target server to fetch sampled 
+      messages.
+    producer_id (int or List[int]) ): The sequence ids of created sampling producer 
+      on the target server.
+    prefetch_size (int): The number of messages to prefetch for every server. 
+      (Default ``2``).
   """
-  def __init__(self,
-               server_rank: int,
-               producer_id: int,
-               num_expected: int,
-               prefetch_size: int = 4):
-    self.server_rank = server_rank
-    self.producer_id = producer_id
-    self.num_expected = num_expected
-    self.prefetch_size = prefetch_size
-    self.num_request = 0
-    self.num_received = 0
-    self.queue = queue.Queue(maxsize=self.prefetch_size)
+
+  def __init__(
+    self,
+    server_rank: Union[int, List[int]],
+    producer_id: Union[int, List[int]],
+    prefetch_size: int = 2
+  ):
+    self.server_rank_list = server_rank if isinstance(server_rank,
+                                                      List) else [server_rank]
+    self.producer_id_list = producer_id if isinstance(producer_id,
+                                                      List) else [producer_id]
+    self.prefetch_size_list = [prefetch_size] * len(self.server_rank_list)
+
+    assert len(self.server_rank_list) == len(self.producer_id_list)
+    assert len(self.server_rank_list) == len(self.prefetch_size_list)
+
+    self.num_request_list = [0] * len(self.server_rank_list)
+    self.num_received_list = [0] * len(self.server_rank_list)
+    self.server_end_of_epoch = [False] * len(self.server_rank_list)
+    self.global_end_of_epoch = False
+
+    self.queue = queue.Queue(maxsize=sum(self.prefetch_size_list))
 
   def reset(self):
     r""" Reset all states to start a new epoch consuming.
@@ -50,36 +62,70 @@ class RemoteReceivingChannel(ChannelBase):
     # Discard messages that have not been consumed.
     while not self.queue.empty():
       _ = self.queue.get()
-    self.num_request = 0
-    self.num_received = 0
+  
+    self.server_end_of_epoch = [False] * len(self.server_rank_list)
+    self.num_request_list = [0] * len(self.server_rank_list)
+    self.num_received_list = [0] * len(self.server_rank_list)
+    self.global_end_of_epoch = False
 
   def send(self, msg: SampleMessage, **kwargs):
-    raise RuntimeError(f"'{self.__class__.__name__}': cannot send "
-                       f"message with a receiving channel.")
+    raise RuntimeError(
+      f"'{self.__class__.__name__}': cannot send "
+      f"message with a receiving channel."
+    )
 
   def recv(self, **kwargs) -> SampleMessage:
-    self._request_some()
-    msg = self.queue.get()
-    self.num_received += 1
+    if self.global_end_of_epoch:
+      if self._all_received():
+        raise StopIteration
+    else:
+      self._request_some()
+    msg, end_of_epoch, local_server_idx = self.queue.get()
+    self.num_received_list[local_server_idx] += 1
+  
+    while end_of_epoch:
+      self.server_end_of_epoch[local_server_idx] = True
+      if sum(self.server_end_of_epoch) == len(self.server_rank_list):
+        self.global_end_of_epoch = True
+        if self._all_received():
+          raise StopIteration
+      msg, end_of_epoch, local_server_idx = self.queue.get()
+      self.num_received_list[local_server_idx] += 1
     return msg
+  
+  def _all_received(self):
+    return sum(self.num_received_list) == sum(self.num_request_list)
 
   def _request_some(self):
-    def on_done(f: torch.futures.Future):
+
+    def on_done(f: torch.futures.Future, local_server_idx):
       try:
-        msg = f.wait()
-        self.queue.put(msg)
+        msg, end_of_epoch = f.wait()
+        self.queue.put((msg, end_of_epoch, local_server_idx))
+
       except Exception as e:
         logging.error("broken future of receiving remote messages: %s", e)
 
+    def create_callback(local_server_idx):
+
+      def callback(f):
+        on_done(f, local_server_idx)
+
+      return callback
+
     from ..distributed import async_request_server, DistServer
 
-    nun_req_limit = min(self.num_received + self.prefetch_size,
-                        self.num_expected)
-    for _ in range(nun_req_limit - self.num_request):
-      fut = async_request_server(
-        self.server_rank,
-        DistServer.fetch_one_sampled_message,
-        self.producer_id
-      )
-      fut.add_done_callback(on_done)
-      self.num_request += 1
+    for local_server_idx, server_rank in enumerate(self.server_rank_list):
+      if not self.server_end_of_epoch[local_server_idx]:
+        for _ in range(
+          self.num_received_list[local_server_idx] +
+          self.prefetch_size_list[local_server_idx] -
+          self.num_request_list[local_server_idx]
+        ):
+          fut = async_request_server(
+            server_rank, DistServer.fetch_one_sampled_message,
+            self.producer_id_list[local_server_idx]
+          )
+          cb = create_callback(local_server_idx)
+          fut.add_done_callback(cb)
+          self.num_request_list[local_server_idx] += 1

--- a/graphlearn_torch/python/channel/shm_channel.py
+++ b/graphlearn_torch/python/channel/shm_channel.py
@@ -52,8 +52,13 @@ class ShmChannel(ChannelBase):
     """
     self._queue.pin_memory()
 
+  def empty(self) -> bool:
+    r""" Whether the queue is empty.
+    """
+    return self._queue.empty()
+
   def send(self, msg: SampleMessage, **kwargs):
     self._queue.send(msg)
 
-  def recv(self, **kwargs) -> SampleMessage:
-    return self._queue.receive()
+  def recv(self, timeout_ms=100, **kwargs) -> SampleMessage:
+    return self._queue.receive(timeout_ms=timeout_ms)

--- a/graphlearn_torch/python/channel/shm_channel.py
+++ b/graphlearn_torch/python/channel/shm_channel.py
@@ -60,5 +60,7 @@ class ShmChannel(ChannelBase):
   def send(self, msg: SampleMessage, **kwargs):
     self._queue.send(msg)
 
-  def recv(self, timeout_ms=100, **kwargs) -> SampleMessage:
+  def recv(self, timeout_ms=None, **kwargs) -> SampleMessage:
+    if timeout_ms is None:
+      timeout_ms = 0
     return self._queue.receive(timeout_ms=timeout_ms)

--- a/graphlearn_torch/python/distributed/dist_loader.py
+++ b/graphlearn_torch/python/distributed/dist_loader.py
@@ -27,7 +27,7 @@ from ..sampler import (
 from ..typing import (NodeType, EdgeType, as_str, reverse_edge_type)
 from ..utils import get_available_device, ensure_device, python_exit_status
 
-from .dist_client import request_server, async_request_server
+from .dist_client import request_server
 from .dist_context import get_context
 from .dist_dataset import DistDataset
 from .dist_options import (
@@ -166,9 +166,8 @@ class DistLoader(object):
 
       self._server_rank_list = self.worker_options.server_rank \
         if isinstance(self.worker_options.server_rank, List) else [self.worker_options.server_rank]
-      self._input_data_list = self.input_data if isinstance(
-        self.input_data, List
-      ) else [self.input_data]
+      self._input_data_list = self.input_data \
+        if isinstance(self.input_data, List) else [self.input_data]
 
       self._input_type = self._input_data_list[0].input_type
 

--- a/graphlearn_torch/python/distributed/dist_neighbor_loader.py
+++ b/graphlearn_torch/python/distributed/dist_neighbor_loader.py
@@ -21,7 +21,7 @@ from ..sampler import NodeSamplerInput, SamplingType, SamplingConfig, RemoteNode
 from ..typing import InputNodes, NumNeighbors
 
 from .dist_dataset import DistDataset
-from .dist_options import AllDistSamplingWorkerOptions
+from .dist_options import AllDistSamplingWorkerOptions, RemoteDistSamplingWorkerOptions
 from .dist_loader import DistLoader
 
 
@@ -87,17 +87,18 @@ class DistNeighborLoader(DistLoader):
       input_type, input_seeds = input_nodes
     else:
       input_type, input_seeds = None, input_nodes
-
-    if isinstance(input_seeds, torch.Tensor):
-      input_data = NodeSamplerInput(node=input_seeds, input_type=input_type)
-    elif isinstance(input_seeds, List):
-      input_data = []
-      for elem in input_seeds:
-        input_data.append(RemoteNodeSamplerInput(node_path=elem, input_type=input_type))
-    elif isinstance(input_seeds, str):
-      input_data = RemoteNodeSamplerInput(node_path=input_seeds, input_type=input_type)
+    
+    if isinstance(worker_options, RemoteDistSamplingWorkerOptions):
+      if isinstance(input_seeds, List):
+        input_data = []
+        for elem in input_seeds:
+          input_data.append(RemoteNodeSamplerInput(node_path=elem, input_type=input_type))
+      elif isinstance(input_seeds, str):
+        input_data = RemoteNodeSamplerInput(node_path=input_seeds, input_type=input_type)
+      else:
+        raise ValueError("Invalid input seeds")
     else:
-      raise ValueError
+      input_data = NodeSamplerInput(node=input_seeds, input_type=input_type)
 
     sampling_config = SamplingConfig(
       SamplingType.NODE, num_neighbors, batch_size, shuffle,

--- a/graphlearn_torch/python/distributed/dist_neighbor_loader.py
+++ b/graphlearn_torch/python/distributed/dist_neighbor_loader.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Optional, Literal
+from typing import Optional, Literal, List
 
 import torch
 
-from ..sampler import NodeSamplerInput, SamplingType, SamplingConfig
+from ..sampler import NodeSamplerInput, SamplingType, SamplingConfig, RemoteNodeSamplerInput
 from ..typing import InputNodes, NumNeighbors
 
 from .dist_dataset import DistDataset
@@ -82,11 +82,22 @@ class DistNeighborLoader(DistLoader):
                collect_features: bool = False,
                to_device: Optional[torch.device] = None,
                worker_options: Optional[AllDistSamplingWorkerOptions] = None):
+    
     if isinstance(input_nodes, tuple):
       input_type, input_seeds = input_nodes
     else:
       input_type, input_seeds = None, input_nodes
-    input_data = NodeSamplerInput(node=input_seeds, input_type=input_type)
+
+    if isinstance(input_seeds, torch.Tensor):
+      input_data = NodeSamplerInput(node=input_seeds, input_type=input_type)
+    elif isinstance(input_seeds, List):
+      input_data = []
+      for elem in input_seeds:
+        input_data.append(RemoteNodeSamplerInput(node_path=elem, input_type=input_type))
+    elif isinstance(input_seeds, str):
+      input_data = RemoteNodeSamplerInput(node_path=input_seeds, input_type=input_type)
+    else:
+      raise ValueError
 
     sampling_config = SamplingConfig(
       SamplingType.NODE, num_neighbors, batch_size, shuffle,

--- a/graphlearn_torch/python/distributed/dist_options.py
+++ b/graphlearn_torch/python/distributed/dist_options.py
@@ -240,7 +240,8 @@ class RemoteDistSamplingWorkerOptions(_BasicDistSamplingWorkerOptions):
                num_rpc_threads: Optional[int] = None,
                rpc_timeout: float = 180,
                buffer_size: Optional[Union[int, str]] = None,
-               prefetch_size: int = 4):
+               prefetch_size: int = 4,
+               worker_key: str = None):
     super().__init__(num_workers, worker_devices, worker_concurrency,
                      master_addr, master_port, num_rpc_threads, rpc_timeout)
 
@@ -256,6 +257,7 @@ class RemoteDistSamplingWorkerOptions(_BasicDistSamplingWorkerOptions):
       raise ValueError(f"'{self.__class__.__name__}': the prefetch count "
                        f"{self.prefetch_size} exceeds the buffer capacity "
                        f"{self.buffer_capacity}")
+    self.worker_key = worker_key
 
 
 AllDistSamplingWorkerOptions = Union[

--- a/graphlearn_torch/python/distributed/dist_sampling_producer.py
+++ b/graphlearn_torch/python/distributed/dist_sampling_producer.py
@@ -29,6 +29,7 @@ from ..sampler import (
 )
 from ..utils import ensure_device
 
+from ..distributed.dist_context import get_context
 from .dist_context import init_worker_group
 from .dist_dataset import DistDataset
 from .dist_neighbor_sampler import DistNeighborSampler
@@ -57,6 +58,7 @@ def _sampling_worker_loop(rank,
                           worker_options: _BasicDistSamplingWorkerOptions,
                           channel: ChannelBase,
                           task_queue: mp.Queue,
+                          sampling_completed_worker_count: mp.Value,
                           mp_barrier):
   r""" Subprocess work loop for sampling worker.
   """
@@ -132,6 +134,10 @@ def _sampling_worker_loop(rank,
             dist_sampler.subgraph(sampler_input[index])
 
         dist_sampler.wait_all()
+
+        with sampling_completed_worker_count.get_lock():
+          sampling_completed_worker_count.value += 1 # non-atomic, lock is necessary
+
       elif command == MpCommand.STOP:
         keep_running = False
       else:
@@ -165,6 +171,9 @@ class DistMpSamplingProducer(object):
     self.worker_options._assign_worker_devices()
     self.num_workers = self.worker_options.num_workers
     self.output_channel = output_channel
+    self.sampling_completed_worker_count = mp.Value('I', lock=True)
+    current_ctx = get_context()
+    self.worker_options._set_worker_ranks(current_ctx)  
 
     self._task_queues = []
     self._workers = []
@@ -190,7 +199,7 @@ class DistMpSamplingProducer(object):
         target=_sampling_worker_loop,
         args=(rank, self.data, self.sampler_input, unshuffled_indexes[rank],
               self.sampling_config, self.worker_options, self.output_channel,
-              task_queue, barrier)
+              task_queue, self.sampling_completed_worker_count, barrier)
       )
       w.daemon = True
       w.start()
@@ -225,9 +234,17 @@ class DistMpSamplingProducer(object):
     else:
       seeds_indexes = [None] * self.num_workers
 
+    self.sampling_completed_worker_count.value = 0
     for rank in range(self.num_workers):
       self._task_queues[rank].put((MpCommand.SAMPLE_ALL, seeds_indexes[rank]))
     time.sleep(0.1)
+
+  def is_all_sampling_completed_and_consumed(self):
+    if self.output_channel.empty():
+      return self.is_all_sampling_completed()
+ 
+  def is_all_sampling_completed(self):
+    return self.sampling_completed_worker_count.value == self.num_workers
 
   def _get_worker_seeds_ranges(self):
     num_worker_batches = [0] * self.num_workers

--- a/graphlearn_torch/python/distributed/dist_server.py
+++ b/graphlearn_torch/python/distributed/dist_server.py
@@ -20,8 +20,8 @@ from typing import Dict, Optional, Union
 
 import torch
 
-from ..channel import ShmChannel
-from ..sampler import NodeSamplerInput, EdgeSamplerInput, SamplingConfig
+from ..channel import ShmChannel, QueueTimeoutError
+from ..sampler import NodeSamplerInput, EdgeSamplerInput, SamplingConfig, RemoteSamplerInput
 
 from .dist_context import get_context, _set_server_context
 from .dist_dataset import DistDataset
@@ -33,7 +33,6 @@ from .rpc import barrier, init_rpc, shutdown_rpc
 SERVER_EXIT_STATUS_CHECK_INTERVAL = 5.0
 r""" Interval (in seconds) to check exit status of server.
 """
-
 
 class DistServer(object):
   r""" A server that supports launching remote sampling workers for
@@ -52,8 +51,10 @@ class DistServer(object):
     self._lock = threading.RLock()
     self._exit = False
     self._producer_idx = 0
+    self._producer_key2idx: Dict[str, int] = {}
     self._producer_pool: Dict[int, DistMpSamplingProducer] = {}
     self._msg_buffer_pool: Dict[int, ShmChannel] = {}
+    self._epoch_pool: Dict[int, int] = {}
 
   def shutdown(self):
     for producer_id in list(self._producer_pool.keys()):
@@ -82,7 +83,7 @@ class DistServer(object):
 
   def create_sampling_producer(
     self,
-    sampler_input: Union[NodeSamplerInput, EdgeSamplerInput],
+    sampler_input: Union[NodeSamplerInput, EdgeSamplerInput, RemoteSamplerInput],
     sampling_config: SamplingConfig,
     worker_options: RemoteDistSamplingWorkerOptions,
   ) -> int:
@@ -99,49 +100,68 @@ class DistServer(object):
     Returns:
       A unique id of created sampling producer on this server.
     """
-    buffer = ShmChannel(
-      worker_options.buffer_capacity, worker_options.buffer_size
-    )
-    producer = DistMpSamplingProducer(
-      self.dataset, sampler_input, sampling_config, worker_options, buffer
-    )
-    producer.init()
-
-    with self._lock:
-      producer_id = self._producer_idx
-      self._producer_pool[producer_id] = producer
-      self._msg_buffer_pool[producer_id] = buffer
-      self._producer_idx += 1
-
+    if isinstance(sampler_input, RemoteSamplerInput):
+      sampler_input = sampler_input.to_local_sampler_input()
+    
+    with self._lock: 
+      producer_id = self._producer_key2idx.get(worker_options.worker_key)
+      if producer_id is None:
+        producer_id = self._producer_idx
+        self._producer_key2idx[worker_options.worker_key] = producer_id
+        self._producer_idx += 1
+        buffer = ShmChannel(
+          worker_options.buffer_capacity, worker_options.buffer_size
+        )
+        producer = DistMpSamplingProducer(
+          self.dataset, sampler_input, sampling_config, worker_options, buffer
+        )
+        producer.init()
+        self._producer_pool[producer_id] = producer
+        self._msg_buffer_pool[producer_id] = buffer
+        self._epoch_pool[producer_id] = -1
     return producer_id
 
   def destroy_sampling_producer(self, producer_id: int):
     r""" Shutdown and destroy a sampling producer managed by this server with
     its producer id.
     """
-    producer = self._producer_pool.get(producer_id, None)
-    if producer is not None:
-      producer.shutdown()
-      with self._lock:
+    with self._lock:
+      producer = self._producer_pool.get(producer_id, None)
+      if producer is not None:
+        producer.shutdown()
         self._producer_pool.pop(producer_id)
         self._msg_buffer_pool.pop(producer_id)
+        self._epoch_pool.pop(producer_id)
 
-  def start_new_epoch_sampling(self, producer_id: int):
+  def start_new_epoch_sampling(self, producer_id: int, epoch: int):
     r""" Start a new epoch sampling tasks for a specific sampling producer
     with its producer id.
     """
-    producer = self._producer_pool.get(producer_id, None)
-    if producer is not None:
-      producer.produce_all()
+    with self._lock:
+      cur_epoch = self._epoch_pool[producer_id]
+      if cur_epoch < epoch:
+        self._epoch_pool[producer_id] = epoch
+        producer = self._producer_pool.get(producer_id, None)
+        if producer is not None:
+          producer.produce_all()
 
   def fetch_one_sampled_message(self, producer_id: int):
     r""" Fetch a sampled message from the buffer of a specific sampling
     producer with its producer id.
     """
+    producer = self._producer_pool.get(producer_id, None)
+    if producer is not None and producer.is_all_sampling_completed_and_consumed():
+      return None, True
     buffer = self._msg_buffer_pool.get(producer_id, None)
     if buffer is None:
-      return None
-    return buffer.recv()
+      return None, False
+    while True:
+        try:
+            msg = buffer.recv(timeout_ms=500)
+            return msg, False
+        except QueueTimeoutError as e:
+            if producer.is_all_sampling_completed():
+                return None, True
 
 
 _dist_server: DistServer = None

--- a/graphlearn_torch/python/distributed/dist_server.py
+++ b/graphlearn_torch/python/distributed/dist_server.py
@@ -17,8 +17,7 @@ import logging
 import time
 import threading
 from typing import Dict, Optional, Union
-
-import torch
+import warnings
 
 from ..channel import ShmChannel, QueueTimeoutError
 from ..sampler import NodeSamplerInput, EdgeSamplerInput, SamplingConfig, RemoteSamplerInput
@@ -50,11 +49,13 @@ class DistServer(object):
     self.dataset = dataset
     self._lock = threading.RLock()
     self._exit = False
-    self._producer_idx = 0
-    self._producer_key2idx: Dict[str, int] = {}
+    self._cur_producer_idx = 0 # auto incremental index (same as producer count)
+    # The mapping from the key in worker options (such as 'train', 'test')
+    # to producer id
+    self._worker_key2producer_id: Dict[str, int] = {}  
     self._producer_pool: Dict[int, DistMpSamplingProducer] = {}
     self._msg_buffer_pool: Dict[int, ShmChannel] = {}
-    self._epoch_pool: Dict[int, int] = {}
+    self._epoch: Dict[int, int] = {} # last epoch for the producer
 
   def shutdown(self):
     for producer_id in list(self._producer_pool.keys()):
@@ -104,11 +105,11 @@ class DistServer(object):
       sampler_input = sampler_input.to_local_sampler_input()
     
     with self._lock: 
-      producer_id = self._producer_key2idx.get(worker_options.worker_key)
+      producer_id = self._worker_key2producer_id.get(worker_options.worker_key)
       if producer_id is None:
-        producer_id = self._producer_idx
-        self._producer_key2idx[worker_options.worker_key] = producer_id
-        self._producer_idx += 1
+        producer_id = self._cur_producer_idx
+        self._worker_key2producer_id[worker_options.worker_key] = producer_id
+        self._cur_producer_idx += 1
         buffer = ShmChannel(
           worker_options.buffer_capacity, worker_options.buffer_size
         )
@@ -118,7 +119,7 @@ class DistServer(object):
         producer.init()
         self._producer_pool[producer_id] = producer
         self._msg_buffer_pool[producer_id] = buffer
-        self._epoch_pool[producer_id] = -1
+        self._epoch[producer_id] = -1
     return producer_id
 
   def destroy_sampling_producer(self, producer_id: int):
@@ -131,16 +132,16 @@ class DistServer(object):
         producer.shutdown()
         self._producer_pool.pop(producer_id)
         self._msg_buffer_pool.pop(producer_id)
-        self._epoch_pool.pop(producer_id)
+        self._epoch.pop(producer_id)
 
   def start_new_epoch_sampling(self, producer_id: int, epoch: int):
     r""" Start a new epoch sampling tasks for a specific sampling producer
     with its producer id.
     """
     with self._lock:
-      cur_epoch = self._epoch_pool[producer_id]
+      cur_epoch = self._epoch[producer_id]
       if cur_epoch < epoch:
-        self._epoch_pool[producer_id] = epoch
+        self._epoch[producer_id] = epoch
         producer = self._producer_pool.get(producer_id, None)
         if producer is not None:
           producer.produce_all()
@@ -150,11 +151,12 @@ class DistServer(object):
     producer with its producer id.
     """
     producer = self._producer_pool.get(producer_id, None)
-    if producer is not None and producer.is_all_sampling_completed_and_consumed():
+    if producer is None:
+      warnings.warn('invalid producer_id {producer_id}')
+      return None, False
+    if producer.is_all_sampling_completed_and_consumed():
       return None, True
     buffer = self._msg_buffer_pool.get(producer_id, None)
-    if buffer is None:
-      return None, False
     while True:
         try:
             msg = buffer.recv(timeout_ms=500)

--- a/graphlearn_torch/python/distributed/rpc.py
+++ b/graphlearn_torch/python/distributed/rpc.py
@@ -291,8 +291,8 @@ def init_rpc(master_addr: str,
     _rpc_current_group_worker_names = set(_rpc_worker_names[ctx.role])
 
     global_barrier(timeout=rpc_timeout) 
-    # TODO(hongyi): without this line, some process may hang when calling 
-    # global barrier
+    # TODO(hongyi): in server-client mode, if "torch.distributed.init_process_group" follows "global_barrier", 
+    # some participants may randomly hang
     time.sleep(1) 
 
 def shutdown_rpc(graceful=True):

--- a/graphlearn_torch/python/distributed/rpc.py
+++ b/graphlearn_torch/python/distributed/rpc.py
@@ -289,7 +289,7 @@ def init_rpc(master_addr: str,
     global _rpc_current_group_worker_names
     _rpc_current_group_worker_names = set(_rpc_worker_names[ctx.role])
 
-    global_barrier(timeout=rpc_timeout)
+    global_barrier(timeout=15) # TODO(hongyi): some may hang here
 
 
 def shutdown_rpc(graceful=True):

--- a/graphlearn_torch/python/distributed/rpc.py
+++ b/graphlearn_torch/python/distributed/rpc.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import atexit
+import time
 import collections
 import functools
 import logging
@@ -289,8 +290,10 @@ def init_rpc(master_addr: str,
     global _rpc_current_group_worker_names
     _rpc_current_group_worker_names = set(_rpc_worker_names[ctx.role])
 
-    global_barrier(timeout=15) # TODO(hongyi): some may hang here
-
+    global_barrier(timeout=rpc_timeout) 
+    # TODO(hongyi): without this line, some process may hang when calling 
+    # global barrier
+    time.sleep(1) 
 
 def shutdown_rpc(graceful=True):
   r""" Shutdown rpc agent on the current process.

--- a/graphlearn_torch/python/py_export.cc
+++ b/graphlearn_torch/python/py_export.cc
@@ -121,13 +121,17 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     .def(py::init<const Graph*>())
     .def("node_subgraph", &CPUSubGraphOp::NodeSubGraph,
          py::arg("srcs"), py::arg("with_edge"));
+  
+  py::register_exception<QueueTimeoutError>(m, "QueueTimeoutError");
 
   py::class_<SampleQueue>(m, "SampleQueue")
     .def(py::init<size_t, size_t>(), py::arg("capacity"), py::arg("buf_size"))
     .def("pin_memory", &SampleQueue::PinMemory)
+    .def("empty", &SampleQueue::Empty,
+         py::call_guard<py::gil_scoped_release>())
     .def("send", &SampleQueue::Enqueue, py::arg("msg"),
          py::call_guard<py::gil_scoped_release>())
-    .def("receive", &SampleQueue::Dequeue,
+    .def("receive", &SampleQueue::Dequeue, py::arg("timeout_ms"),
          py::call_guard<py::gil_scoped_release>())
     .def(py::pickle(
         [](const SampleQueue& q) { // __getstate__

--- a/graphlearn_torch/python/sampler/base.py
+++ b/graphlearn_torch/python/sampler/base.py
@@ -403,3 +403,32 @@ class BaseSampler(ABC):
       and a mapping from indices in `inputs` to new indices in output nodes,
       i.e. nodes[mapping] = inputs.
     """
+
+class RemoteSamplerInput(ABC):
+  """A base class that provides the `to_local_sampler_input` method for the server
+  to obtain the sampler input.
+  """
+  
+  @abstractmethod
+  def to_local_sampler_input(
+    self,
+  ) -> Union[NodeSamplerInput, EdgeSamplerInput]:
+    r"""
+    Abstract method to convert the sampler input to local format.
+    """
+
+
+class RemoteNodeSamplerInput(RemoteSamplerInput):
+  r"""RemoteNodeSamplerInput passes the node path to the server, where the server
+  can load node seeds from it.
+  """
+  def __init__(self, node_path: str, input_type: str ) -> None:
+    self.node_path = node_path
+    self.input_type = input_type
+
+  def to_local_sampler_input(
+    self,
+  ) -> NodeSamplerInput:
+    
+    node = torch.load(self.node_path)
+    return NodeSamplerInput(node=node, input_type=self.input_type)

--- a/graphlearn_torch/python/typing.py
+++ b/graphlearn_torch/python/typing.py
@@ -81,7 +81,8 @@ HeteroEdgePartitionDict = Dict[EdgeType, PartitionBook]
 
 # Types for neighbor sampling ##################################################
 
-InputNodes = Union[torch.Tensor, NodeType, Tuple[NodeType, torch.Tensor]]
+Seeds = Union[torch.Tensor, str] 
+InputNodes = Union[Seeds, NodeType, Tuple[NodeType, Seeds], Tuple[NodeType, List[Seeds]]]
 EdgeIndexTensor = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
 InputEdges = Union[EdgeIndexTensor, EdgeType, Tuple[EdgeType, EdgeIndexTensor]]
 NumNeighbors = Union[List[int], Dict[EdgeType, List[int]]]

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -11,6 +11,7 @@ set -x
 
 bash install_dependencies.sh
 pip install ninja
+pip install parameterized
 cmake .
 make -j$CORES
 python setup.py bdist_wheel

--- a/test/cpp/test_shm_queue.cu
+++ b/test/cpp/test_shm_queue.cu
@@ -100,7 +100,7 @@ TEST_F(ShmQueueTest, Functionality) {
       // Receiver
       for (int r = 0; r < 10; r++) {
         // receive test msg
-        auto shm_data = shq_->Dequeue();
+        auto shm_data = shq_->Dequeue(100);
         auto test_msg = TestMsg::Load(shm_data);
         // send verify msg
         VerifyMsg verify_msg{test_msg.id, VerifyMsg::BehvType::Receive};
@@ -120,7 +120,8 @@ TEST_F(ShmQueueTest, Functionality) {
 
     std::unordered_set<int> sent_msgs, received_msgs;
     for (int i = 0; i < 40; i++) {
-      auto shm_data = res_shq_->Dequeue();
+      EXPECT_FALSE(res_shq_->Empty());
+      auto shm_data = res_shq_->Dequeue(100);
       auto* verify_msg = static_cast<const VerifyMsg*>(shm_data.Data());
       if (verify_msg->type == VerifyMsg::BehvType::Send) {
         EXPECT_EQ(sent_msgs.count(verify_msg->id), 0);
@@ -131,6 +132,13 @@ TEST_F(ShmQueueTest, Functionality) {
         received_msgs.insert(verify_msg->id);
       }
     }
+    try {
+      auto shm_data = res_shq_->Dequeue(100);
+    }
+    catch (const QueueTimeoutError& e) {
+      std::cout << "Expected QueueTimeoutError: " << e.what() << std::endl;
+    }
+    EXPECT_TRUE(res_shq_->Empty());
     EXPECT_EQ(sent_msgs.size(), 20);
     EXPECT_EQ(received_msgs.size(), 20);
   }

--- a/test/cpp/test_shm_queue.cu
+++ b/test/cpp/test_shm_queue.cu
@@ -100,7 +100,7 @@ TEST_F(ShmQueueTest, Functionality) {
       // Receiver
       for (int r = 0; r < 10; r++) {
         // receive test msg
-        auto shm_data = shq_->Dequeue(100);
+        auto shm_data = shq_->Dequeue();
         auto test_msg = TestMsg::Load(shm_data);
         // send verify msg
         VerifyMsg verify_msg{test_msg.id, VerifyMsg::BehvType::Receive};
@@ -121,7 +121,7 @@ TEST_F(ShmQueueTest, Functionality) {
     std::unordered_set<int> sent_msgs, received_msgs;
     for (int i = 0; i < 40; i++) {
       EXPECT_FALSE(res_shq_->Empty());
-      auto shm_data = res_shq_->Dequeue(100);
+      auto shm_data = res_shq_->Dequeue();
       auto* verify_msg = static_cast<const VerifyMsg*>(shm_data.Data());
       if (verify_msg->type == VerifyMsg::BehvType::Send) {
         EXPECT_EQ(sent_msgs.count(verify_msg->id), 0);
@@ -133,7 +133,7 @@ TEST_F(ShmQueueTest, Functionality) {
       }
     }
     try {
-      auto shm_data = res_shq_->Dequeue(100);
+      auto shm_data = res_shq_->Dequeue(10);
     }
     catch (const QueueTimeoutError& e) {
       std::cout << "Expected QueueTimeoutError: " << e.what() << std::endl;

--- a/test/python/test_shm_channel.py
+++ b/test/python/test_shm_channel.py
@@ -47,7 +47,7 @@ def run_receiver(_, channel):
     tc.assertTrue(torch.equal(received_map['from_cuda'],
                               torch.arange(i, dtype=torch.int32)))
   try:
-    channel.recv()
+    channel.recv(10)
   except QueueTimeoutError as e:
     print('Expected Error', e)
   tc.assertTrue(channel.empty())

--- a/test/python/test_shm_channel.py
+++ b/test/python/test_shm_channel.py
@@ -17,7 +17,7 @@ import unittest
 import torch
 import torch.multiprocessing as mp
 
-from graphlearn_torch.channel import ShmChannel
+from graphlearn_torch.channel import ShmChannel, QueueTimeoutError
 
 
 def run_sender(_, channel):
@@ -46,6 +46,11 @@ def run_receiver(_, channel):
     tc.assertEqual(received_map['from_cuda'].device, torch.device('cpu'))
     tc.assertTrue(torch.equal(received_map['from_cuda'],
                               torch.arange(i, dtype=torch.int32)))
+  try:
+    channel.recv()
+  except QueueTimeoutError as e:
+    print('Expected Error', e)
+  tc.assertTrue(channel.empty())
 
 
 class SampleQueueCase(unittest.TestCase):


### PR DESCRIPTION
Overiew:
1. Instead of having the client load input data, the input data is placed on servers. The client pass a RemoteSamplerInput to the server, and the server will then load the input data from the specified location.
2. Allow for arbitrary connections between servers and clients. For example, both the following scenarios should be allowed:
- Let client0 connect to server0 and server1. Let client1 connect to server0 and server1.
- Let client0 connect to server0. Let client1 connect to server1.

Detailed Changes:
1. Roll back the changes made to the partition example and keep the number of input data partitions and datasets the same.
2. Add an empty method and include a timeout parameter in the receive method for the shared memory (shm) channel.
4. Refactor the RemoteReceivingChannel to allow for the server_rank parameter as a list.
5. Let the server signal the end of an epoch.
6. Provide a RemoteSamplerInput abstraction and the implementation of RemoteNodeSamplerInput.