### PR TITLE
Fix: skip sampling empty inputs

### DIFF
--- a/graphlearn_torch/python/distributed/dist_neighbor_sampler.py
+++ b/graphlearn_torch/python/distributed/dist_neighbor_sampler.py
@@ -283,12 +283,12 @@ class DistNeighborSampler(ConcurrentEventLoop):
           req_num = self.num_neighbors[etype][i]
           if self.edge_dir == 'in':
             srcs = src_dict.get(etype[-1], None)
-            if srcs is not None:
+            if srcs is not None and srcs.numel() > 0:
               task_dict[reverse_edge_type(etype)] = self._loop.create_task(
                 self._sample_one_hop(srcs, req_num, etype))
           elif self.edge_dir == 'out':
             srcs = src_dict.get(etype[0], None)
-            if srcs is not None:
+            if srcs is not None and srcs.numel() > 0:
               task_dict[etype] = self._loop.create_task(
                 self._sample_one_hop(srcs, req_num, etype))
 

--- a/graphlearn_torch/python/sampler/neighbor_sampler.py
+++ b/graphlearn_torch/python/sampler/neighbor_sampler.py
@@ -234,7 +234,7 @@ class NeighborSampler(BaseSampler):
         # out sampling needs dst_type==seed_type, in sampling needs src_type==seed_type
         if self.edge_dir == 'in':
           src = src_dict.get(etype[-1], None)
-          if src is not None:
+          if src is not None and src.numel() > 0:
             output = self.sample_one_hop(src, req_num, etype)
             if output.nbr.numel() == 0:
               continue
@@ -243,7 +243,7 @@ class NeighborSampler(BaseSampler):
               edge_dict[reverse_edge_type(etype)] = output.edge
         elif self.edge_dir == 'out':
           src = src_dict.get(etype[0], None)
-          if src is not None:
+          if src is not None and src.numel() > 0:
             output = self.sample_one_hop(src, req_num, etype)
             if output.nbr.numel() == 0:
               continue


### PR DESCRIPTION
This PR skips sampling if its inputs (the induced previous-hop result) is empty, as the sampler kernel reports 'invalid configuration argument' error when the input node tensor is empty. 