### PR TITLE
Allows to load node embeddings into memory with FP16 format

### DIFF
--- a/examples/igbh/dist_train_rgnn.py
+++ b/examples/igbh/dist_train_rgnn.py
@@ -262,7 +262,7 @@ if __name__ == '__main__':
   parser.add_argument('--fan_out', type=str, default='15, 10, 5')
   parser.add_argument('--batch_size', type=int, default=512)
   parser.add_argument('--hidden_channels', type=int, default=128)
-  parser.add_argument('--learning_rate', type=int, default=0.001)
+  parser.add_argument('--learning_rate', type=float, default=0.001)
   parser.add_argument('--epochs', type=int, default=20)
   parser.add_argument('--num_layers', type=int, default=3)
   parser.add_argument('--num_heads', type=int, default=4)

--- a/examples/igbh/train_rgnn.py
+++ b/examples/igbh/train_rgnn.py
@@ -138,7 +138,7 @@ if __name__ == '__main__':
   parser.add_argument('--fan_out', type=str, default='15,10,5')
   parser.add_argument('--batch_size', type=int, default=5120)
   parser.add_argument('--hidden_channels', type=int, default=128)
-  parser.add_argument('--learning_rate', type=int, default=0.01)
+  parser.add_argument('--learning_rate', type=float, default=0.01)
   parser.add_argument('--epochs', type=int, default=20)
   parser.add_argument('--num_layers', type=int, default=3)
   parser.add_argument('--num_heads', type=int, default=4)


### PR DESCRIPTION
This PR gives a new command-line argument `--use_fp16` that, when added, allows the user to load node embeddings into memory with FP16 format. With this argument, the memory-mapped node features will be loaded into memory from disk with FP16 format. This allows users to run the training code on large dataset (IGBH-Large & IGBH-Full, for instance, or IGBH-Medium, which requires >128GB memory) on devices with smaller memory size. 

From our current running result, we see that the accuracy is the same when training with FP16 vs. FP32. This is verified on IGBH-Small, IGBH-Medium, and IGBH-Large. 

We need to note that with this argument, we load all node features into the memory by default, regardless of whether `--in_memory` is true. 

Additionally, this PR also fixes the type of command-line argument `--learning_rate`, so that we can actually control the learning rate from bash script, instead of modifying the actual `.py` file. 