### PR TITLE
[Feat] supports node split for both Dataset and DistDataset

### DIFF
--- a/graphlearn_torch/python/data/dataset.py
+++ b/graphlearn_torch/python/data/dataset.py
@@ -128,7 +128,8 @@ class Dataset(object):
   ):
     r"""Performs a node-level random split by adding :obj:`train_idx`,
     :obj:`val_idx` and :obj:`test_idx` attributes to the
-    :class:`~graphlearn_torch.data.Dataset` object.
+    :class:`~graphlearn_torch.data.Dataset` object. All nodes except 
+    those in the validation and test sets will be used for training.
 
     Args:
       num_val (int or float): The number of validation samples.

--- a/graphlearn_torch/python/data/dataset.py
+++ b/graphlearn_torch/python/data/dataset.py
@@ -15,11 +15,12 @@
 
 import logging
 from multiprocessing.reduction import ForkingPickler
-from typing import Dict, List, Optional, Union, Literal
+from typing import Dict, List, Optional, Union, Literal, Tuple
+from enum import Enum
 
 import torch
 
-from ..typing import NodeType, EdgeType, TensorDataType
+from ..typing import NodeType, EdgeType, TensorDataType, NodeLabel, NodeIndex
 from ..utils import convert_to_tensor, share_memory, squeeze
 
 from .feature import DeviceGroup, Feature
@@ -34,14 +35,20 @@ class Dataset(object):
     graph: Union[Graph, Dict[EdgeType, Graph]] = None,
     node_features: Union[Feature, Dict[NodeType, Feature]] = None,
     edge_features: Union[Feature, Dict[EdgeType, Feature]] = None,
-    node_labels: Union[TensorDataType, Dict[NodeType, TensorDataType]] = None,
-    edge_dir: Literal['in', 'out'] = 'out'
+    node_labels: NodeLabel = None,
+    edge_dir: Literal['in', 'out'] = 'out',
+    node_split: Tuple[NodeIndex, NodeIndex, NodeIndex] = None,
   ):
     self.graph = graph
     self.node_features = node_features
     self.edge_features = edge_features
     self.node_labels = squeeze(convert_to_tensor(node_labels))
     self.edge_dir = edge_dir
+
+    if node_split is not None:
+      self.train_idx, self.val_idx, self.test_idx = squeeze(convert_to_tensor(node_split))
+    else:
+      self.train_idx, self.val_idx, self.test_idx = None, None, None
 
   def init_graph(
     self,
@@ -113,6 +120,36 @@ class Dataset(object):
                         layout='CSR' if self.edge_dir == 'out' else 'CSC')
         self.graph = Graph(topo, graph_mode, device)
         self.graph.lazy_init()
+
+  def random_node_split(
+    self,
+    num_val: Union[float, int],
+    num_test: Union[float, int],
+  ):
+    r"""Performs a node-level random split by adding :obj:`train_idx`,
+    :obj:`val_idx` and :obj:`test_idx` attributes to the
+    :class:`~graphlearn_torch.data.Dataset` object.
+
+    Args:
+      num_val (int or float): The number of validation samples.
+        If float, it represents the ratio of samples to include in the
+        validation set.
+      num_test (int or float): The number of test samples in case
+        of :obj:`"train_rest"` and :obj:`"random"` split. If float, it
+        represents the ratio of samples to include in the test set.
+    """
+
+    if isinstance(self.node_labels, dict):
+      train_idx = {}
+      val_idx = {}
+      test_idx = {}
+  
+      for node_type, labels in self.node_labels.items():  
+        train_idx[node_type], val_idx[node_type], test_idx[node_type] = \
+          random_split(labels.shape[0], num_val, num_test)
+    else:
+      train_idx, val_idx, test_idx = random_split(self.node_labels.shape[0], num_val, num_test)
+    self.init_node_split((train_idx, val_idx, test_idx))
 
   def init_node_features(
     self,
@@ -234,14 +271,32 @@ class Dataset(object):
     if node_label_data is not None:
       self.node_labels = squeeze(convert_to_tensor(node_label_data))
 
+  def init_node_split(
+    self,
+    node_split: Tuple[NodeIndex, NodeIndex, NodeIndex] = None,
+  ):
+    r"""Initialize the node split.
+
+    Args:
+      node_split (tuple): A tuple containing the train, validation, and test node indices.
+        (default: ``None``)
+    """
+    if node_split is not None:
+      self.train_idx, self.val_idx, self.test_idx = squeeze(convert_to_tensor(node_split))
+
   def share_ipc(self):
     self.node_labels = share_memory(self.node_labels)
-    return self.graph, self.node_features, self.edge_features, self.node_labels, self.edge_dir
+    self.train_idx = share_memory(self.train_idx)
+    self.val_idx = share_memory(self.val_idx)
+    self.test_idx = share_memory(self.test_idx)
+
+    return self.graph, self.node_features, self.edge_features, self.node_labels, \
+        self.edge_dir, (self.train_idx, self.val_idx, self.test_idx)
 
   @classmethod
   def from_ipc_handle(cls, ipc_handle):
-    graph, node_features, edge_features, node_labels, edge_dir = ipc_handle
-    return cls(graph, node_features, edge_features, node_labels, edge_dir)
+    graph, node_features, edge_features, node_labels, edge_dir, node_split  = ipc_handle
+    return cls(graph, node_features, edge_features, node_labels, edge_dir, node_split)
 
   def get_graph(self, etype: Optional[EdgeType] = None):
     if isinstance(self.graph, Graph):
@@ -350,3 +405,16 @@ def reduce_dataset(dataset: Dataset):
   return (rebuild_dataset, (ipc_handle, ))
 
 ForkingPickler.register(Dataset, reduce_dataset)
+
+def random_split(
+  num_total: int,
+  num_val: Union[float, int],
+  num_test: Union[float, int],
+):    
+  num_val = round(num_total * num_val) if isinstance(num_val, float) else num_val
+  num_test = round(num_total * num_test) if isinstance(num_test, float) else num_test
+  perm = torch.randperm(num_total)
+  val_idx = perm[:num_val].clone()
+  test_idx = perm[num_val:num_val + num_test].clone()
+  train_idx = perm[num_val + num_test:].clone()
+  return train_idx, val_idx, test_idx

--- a/graphlearn_torch/python/distributed/dist_dataset.py
+++ b/graphlearn_torch/python/distributed/dist_dataset.py
@@ -175,8 +175,9 @@ class DistDataset(Dataset):
   ):
     r"""Performs a node-level random split by adding :obj:`train_idx`,
     :obj:`val_idx` and :obj:`test_idx` attributes to the
-    :class:`~graphlearn_torch.distributed.DistDataset` object.
-
+    :class:`~graphlearn_torch.distributed.DistDataset` object. All nodes except 
+    those in the validation and test sets will be used for training.
+    
     Args:
       num_val (int or float): The number of validation samples.
         If float, it represents the ratio of samples to include in the

--- a/graphlearn_torch/python/distributed/dist_server.py
+++ b/graphlearn_torch/python/distributed/dist_server.py
@@ -102,7 +102,7 @@ class DistServer(object):
       A unique id of created sampling producer on this server.
     """
     if isinstance(sampler_input, RemoteSamplerInput):
-      sampler_input = sampler_input.to_local_sampler_input()
+      sampler_input = sampler_input.to_local_sampler_input(dataset=self.dataset)
     
     with self._lock: 
       producer_id = self._worker_key2producer_id.get(worker_options.worker_key)

--- a/graphlearn_torch/python/typing.py
+++ b/graphlearn_torch/python/typing.py
@@ -17,7 +17,7 @@ from typing import Dict, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 import numpy as np
-
+from enum import Enum
 
 # Types for basic graph entity #################################################
 
@@ -45,8 +45,17 @@ def reverse_edge_type(etype: EdgeType):
       edge = 'rev_' + edge
   return (dst, edge, src)
 
+
 # A representation of tensor data
 TensorDataType = Union[torch.Tensor, np.ndarray]
+
+NodeLabel = Union[TensorDataType, Dict[NodeType, TensorDataType]]
+NodeIndex = Union[TensorDataType, Dict[NodeType, TensorDataType]]
+
+class Split(Enum):
+  train = 'train'
+  valid = 'valid'
+  test = 'test'
 
 # Types for partition data #####################################################
 

--- a/test/python/test_dist_neighbor_loader.py
+++ b/test/python/test_dist_neighbor_loader.py
@@ -303,6 +303,10 @@ class DistNeighborLoaderTestCase(unittest.TestCase):
     self.dataset0 = _prepare_dataset(rank=0)
     self.dataset1 = _prepare_dataset(rank=1)
 
+    # all for train
+    self.dataset0.random_node_split(0, 0)
+    self.dataset1.random_node_split(0, 0)
+    
     self.input_nodes0 = torch.arange(vnum_per_partition)
     self.input_nodes1 = torch.arange(vnum_per_partition) + vnum_per_partition
 
@@ -443,21 +447,26 @@ class DistNeighborLoaderTestCase(unittest.TestCase):
     w1.join()
 
   @parameterized.expand([
-    ([[0],[1]], 2, 2),
-    ([[0, 1]], 1, 2),
-    ([[0, 1], [0, 1]], 2, 2),
+    ([[0],[1]], 2, 2, "file_path"),
+    ([[0, 1]], 1, 2, "file_path"),
+    ([[0, 1], [0, 1]], 2, 2, "file_path"),
+    ([[0],[1]], 2, 2, "split"),
+    ([[0, 1]], 1, 2, "split"),
+    ([[0, 1], [0, 1]], 2, 2, "split"),
   ])
-  def test_remote_mode(self, servers_for_clients, num_clients, num_servers):
+  def test_remote_mode(self, servers_for_clients, num_clients, num_servers, input_nodes_type):
     print("\n--- DistNeighborLoader Test (server-client mode, remote) ---")
     print(f"--- num_clients: {num_clients} num_servers: {num_servers} ---")
     for client_rank, servers in enumerate(servers_for_clients):
       print(f'[Client {client_rank}] will connect servers {servers}')
+    print(f"--- input_nodes_type: {input_nodes_type} ---")
 
     self.dataset_list = [self.dataset0, self.dataset1]
-    self.input_nodes_list = [self.input_nodes0_path, self.input_nodes1_path]
+    # self.input_nodes_list = [self.input_nodes0, self.input_nodes1]
+    self.input_nodes_path_list = [self.input_nodes0_path, self.input_nodes1_path]
 
     mp_context = torch.multiprocessing.get_context('spawn')
-
+          
     server_procs = []
     for server_rank in range(num_servers):
       server_procs.append(mp_context.Process(
@@ -468,10 +477,15 @@ class DistNeighborLoaderTestCase(unittest.TestCase):
     client_procs = []
     for client_rank in range(num_clients):
       server_rank_list = servers_for_clients[client_rank]
+      if input_nodes_type == "split":
+        input_nodes = glt.typing.Split.train
+      elif input_nodes_type == "file_path":
+        input_nodes = [self.input_nodes_path_list[server_rank] for server_rank in server_rank_list]
+
       client_procs.append(mp_context.Process(
         target=run_test_as_client,
-        args=(num_servers, num_clients, client_rank, server_rank_list, self.master_port, self.sampling_master_port,
-            [self.input_nodes_list[server_rank] for server_rank in server_rank_list], _check_sample_result)
+        args=(num_servers, num_clients, client_rank, server_rank_list, self.master_port, 
+            self.sampling_master_port, input_nodes, _check_sample_result)
       ))
     for sproc in server_procs:
       sproc.start()


### PR DESCRIPTION
I mimic the [RandomNodeSplit](https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/transforms/random_node_split.html)  in PyG and implement a similar api with simplified functionality for both Dataset and DistDataset in gltorch, with which users can:

1. generate train_idx, val_idx, and test_idx for a node classification task on a dataset:
```
dataset = glt.distributed.DistDataset()
dataset.load(...)
dataset.random_node_split(num_val=0.2, num_test=0.2)
```
2. use the split as input nodes when initializing the DataLoader in server-client mode:
```
dist_loader = glt.distributed.DistNeighborLoader(
  ...
  input_nodes=glt.typing.Split.train,
  ...
)
```
