### PR TITLE
Update IGBH example

### DIFF
--- a/examples/igbh/dataset.py
+++ b/examples/igbh/dataset.py
@@ -100,8 +100,6 @@ class IGBHeteroDataset(object):
     paper_lbl_path = osp.join(self.dir, self.dataset_size, 'processed', 'paper', label_file)
     num_paper_nodes = self.paper_nodes_num[self.dataset_size]
     if self.in_memory:
-      if self.dataset_size in ['large', 'full']:
-        raise Exception(f"Cannot load related files into memory directly")
       paper_node_features = torch.from_numpy(np.load(paper_feat_path))
       paper_node_labels = torch.from_numpy(np.load(paper_lbl_path)).to(torch.long) 
     else:
@@ -117,8 +115,6 @@ class IGBHeteroDataset(object):
     num_author_nodes = self.author_nodes_num[self.dataset_size]
     author_feat_path = osp.join(self.dir, self.dataset_size, 'processed', 'author', 'node_feat.npy')
     if self.in_memory:
-      if self.dataset_size in ['large', 'full']:
-        raise Exception(f"Cannot load related files into memory directly")
       author_node_features = torch.from_numpy(np.load(author_feat_path))
     else:
       if self.dataset_size in ['large', 'full']:
@@ -160,7 +156,7 @@ class IGBHeteroDataset(object):
       self.feat_dict['journal'] = journal_node_features
 
 
-    n_nodes = paper_node_features.shape[0]
+    n_nodes = self.paper_nodes_num[self.dataset_size]
     n_train = int(n_nodes * 0.6)
     n_val = int(n_nodes * 0.2)
 

--- a/examples/igbh/download-igbh-full-p32.py
+++ b/examples/igbh/download-igbh-full-p32.py
@@ -1,0 +1,68 @@
+import os
+import subprocess
+from urllib.parse import urlparse, urlunparse
+
+def download_url(input_url):
+    input_url = input_url.strip()
+    if input_url.endswith("/"):
+        print(f"Skipping folder URL: {input_url}")
+    else:
+        # Replace "oss://graphlearn" with "https://graphlearn.oss-cn-hangzhou.aliyuncs.com"
+        download_url = input_url.replace("oss://graphlearn", "https://graphlearn.oss-cn-hangzhou.aliyuncs.com")
+        print(f"Download: {download_url}")
+
+        parsed_url = urlparse(download_url)
+        url_path = parsed_url.path
+        start_index = url_path.find("igbh-full-partition-32")
+
+        if start_index != -1:
+            folder_path = url_path[start_index:]
+            # Split the path by "/" and exclude the last part
+            folder_parts = folder_path.split("/")[:-1]
+            folder_path = "/".join(folder_parts)
+        else:
+            folder_path = None
+
+        if not os.path.exists(folder_path):
+            os.makedirs(folder_path)
+
+        # Use wget to download the URL
+        wget_command = f"wget {download_url} -P {folder_path}"
+        subprocess.call(wget_command, shell=True)
+
+def process_line(line):
+    # Find the position of "oss://"
+    oss_start = line.find("oss://")
+
+    # Extract the string starting with "oss://"
+    if oss_start != -1:
+        oss_url = line[oss_start:]
+        download_url(oss_url)
+        return 1
+    else:
+        print(f"No 'oss://' found in: {line}")
+        return 0
+
+if __name__ == "__main__":
+    url = "https://graphlearn.oss-cn-hangzhou.aliyuncs.com/data/igbh/igbh-full-partition-32/igbh-full-p32-oss-url.txt"
+    destination_path = "igbh-full-p32-oss-url.txt"
+    # Run wget command to download the file
+    wget_command = f"wget {url} -O {destination_path}"
+    try:
+        subprocess.run(wget_command, shell=True, check=True)
+        print(f"Download file list {destination_path}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error: {e}")
+
+    with open(destination_path, "r") as input_file:
+        processed = 0
+        for line in input_file:
+            print(f"Download file {processed+1}/{2198}")
+            processed += process_line(line)
+        assert processed == 2198 # 2198 objects including the directories
+    print("Download completes!")
+    
+
+
+
+

--- a/examples/igbh/partition.py
+++ b/examples/igbh/partition.py
@@ -41,6 +41,8 @@ def partition_dataset(src_path: str,
 
   print('-- Partitioning training idx ...')
   train_idx = data.train_idx
+  shuffle_idx = torch.randperm(train_idx.size(0))
+  train_idx = train_idx[shuffle_idx]
   train_idx = train_idx.split(train_idx.size(0) // num_partitions)
   train_idx_partitions_dir = osp.join(dst_path, f'{dataset_size}-train-partitions')
   glt.utils.ensure_dir(train_idx_partitions_dir)
@@ -48,15 +50,19 @@ def partition_dataset(src_path: str,
     torch.save(train_idx[pidx], osp.join(train_idx_partitions_dir, f'partition{pidx}.pt'))
 
   print('-- Partitioning validation idx ...')
-  train_idx = data.val_idx
-  train_idx = train_idx.split(train_idx.size(0) // num_partitions)
-  train_idx_partitions_dir = osp.join(dst_path, f'{dataset_size}-val-partitions')
-  glt.utils.ensure_dir(train_idx_partitions_dir)
+  val_idx = data.val_idx
+  shuffle_idx = torch.randperm(val_idx.size(0))
+  val_idx = val_idx[shuffle_idx]
+  val_idx = val_idx.split(val_idx.size(0) // num_partitions)
+  val_idx_partitions_dir = osp.join(dst_path, f'{dataset_size}-val-partitions')
+  glt.utils.ensure_dir(val_idx_partitions_dir)
   for pidx in range(num_partitions):
-    torch.save(train_idx[pidx], osp.join(train_idx_partitions_dir, f'partition{pidx}.pt'))
+    torch.save(val_idx[pidx], osp.join(val_idx_partitions_dir, f'partition{pidx}.pt'))
 
   print('-- Partitioning test idx ...')
   test_idx = data.test_idx
+  shuffle_idx = torch.randperm(test_idx.size(0))
+  test_idx = test_idx[shuffle_idx]
   test_idx = test_idx.split(test_idx.size(0) // num_partitions)
   test_idx_partitions_dir = osp.join(dst_path, f'{dataset_size}-test-partitions')
   glt.utils.ensure_dir(test_idx_partitions_dir)


### PR DESCRIPTION
1. Remove the constraint the igbh-large and igbh-full cannot be loaded using in-memory mode, leave the decision to users.
2. Shuffle the train/test/validation seeds before partitioning
3. Add a script `download-igbh-full-p32.py` to download a pre-partitioned igbh-full dataset (#partitions=32)