### PR TITLE
Fixes the build failure on MacOS and the compile flags settings in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,9 @@ function(add_library_graphlearn_torch_vineyard)
   set(GLT_V6D_CSRC_DIR ${GLT_ROOT}/graphlearn_torch/v6d)
   find_package(vineyard REQUIRED)
   add_library(graphlearn_torch_vineyard SHARED)
-  target_source_tree(graphlearn_torch_vineyard 
-    ${GLT_V6D_CSRC_DIR}/*.cc
-    PROPERTIES COMPILE_FLAGS ${GLT_CXX_FLAGS})
+  target_source_tree(graphlearn_torch_vineyard
+    ${GLT_V6D_CSRC_DIR}/*.cc)
+  target_compile_options(graphlearn_torch_vineyard PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${GLT_CXX_FLAGS}>")
   target_include_directories(graphlearn_torch_vineyard
     PUBLIC ${GLT_ROOT})
   target_include_directories(graphlearn_torch_vineyard
@@ -140,11 +140,10 @@ endif()
 function(add_library_graphlearn_torch)
   add_library(graphlearn_torch SHARED)
   target_source_tree(graphlearn_torch
-    ${GLT_CSRC_DIR}/*.cc
-    PROPERTIES COMPILE_FLAGS ${GLT_CXX_FLAGS})
+    ${GLT_CSRC_DIR}/*.cc)
   target_source_tree(graphlearn_torch
-    ${GLT_CSRC_DIR}/cpu/*.cc
-    PROPERTIES COMPILE_FLAGS ${GLT_CXX_FLAGS})
+    ${GLT_CSRC_DIR}/cpu/*.cc)
+  target_compile_options(graphlearn_torch PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${GLT_CXX_FLAGS}>")
   if(WITH_CUDA)
     target_source_tree(graphlearn_torch
       ${GLT_CSRC_DIR}/cuda/*.cu)

--- a/graphlearn_torch/v6d/vineyard_utils.cc
+++ b/graphlearn_torch/v6d/vineyard_utils.cc
@@ -150,22 +150,22 @@ torch::Tensor ArrowArray2Tensor(
     auto mcol = std::dynamic_pointer_cast<arrow::Int32Array>(fscol);
     auto options = torch::TensorOptions().dtype(torch::kI32).device(torch::kCPU);
     return torch::from_blob(const_cast<int32_t*>(mcol->raw_values()),
-      {mcol->length() / col_num, col_num}, options);
+      {static_cast<int64_t>(mcol->length() / col_num), static_cast<int64_t>(col_num)}, options);
   } else if (fscol->type()->Equals(arrow::int64())) {
     auto mcol = std::dynamic_pointer_cast<arrow::Int64Array>(fscol);
     auto options = torch::TensorOptions().dtype(torch::kI64).device(torch::kCPU);
     return torch::from_blob(const_cast<int64_t*>(mcol->raw_values()),
-      {mcol->length() / col_num, col_num}, options);
+      {static_cast<int64_t>(mcol->length() / col_num), static_cast<int64_t>(col_num)}, options);
   } else if (fscol->type()->Equals(arrow::float32())) { //dtype: float
     auto mcol = std::dynamic_pointer_cast<arrow::FloatArray>(fscol);
     auto options = torch::TensorOptions().dtype(torch::kF32).device(torch::kCPU);
     return torch::from_blob(const_cast<float*>(mcol->raw_values()),
-      {mcol->length() / col_num, col_num}, options);
+      {static_cast<int64_t>(mcol->length() / col_num), static_cast<int64_t>(col_num)}, options);
   } else if (fscol->type()->Equals(arrow::float64())){ //dtype: double
     auto mcol = std::dynamic_pointer_cast<arrow::DoubleArray>(fscol);
     auto options = torch::TensorOptions().dtype(torch::kF64).device(torch::kCPU);
     return torch::from_blob(const_cast<double*>(mcol->raw_values()),
-      {mcol->length() / col_num, col_num}, options);
+      {static_cast<int64_t>(mcol->length() / col_num), static_cast<int64_t>(col_num)}, options);
   } else {
     throw std::runtime_error("Unsupported column type: " + fscol->type()->ToString());
   }


### PR DESCRIPTION
The error message likes:

```
/usr/local/include/vineyard/basic/ds/hashmap.h:36:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
   36 | #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
      |                                ^
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:153:8: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]
  153 |       {mcol->length() / col_num, col_num}, options);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:153:8: note: insert an explicit cast to silence this issue
  153 |       {mcol->length() / col_num, col_num}, options);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
      |        static_cast<long long>( )
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:153:34: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]
  153 |       {mcol->length() / col_num, col_num}, options);
      |                                  ^~~~~~~
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:153:34: note: insert an explicit cast to silence this issue
  153 |       {mcol->length() / col_num, col_num}, options);
      |                                  ^~~~~~~
      |                                  static_cast<long long>( )
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:158:8: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]
  158 |       {mcol->length() / col_num, col_num}, options);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:158:8: note: insert an explicit cast to silence this issue
  158 |       {mcol->length() / col_num, col_num}, options);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
      |        static_cast<long long>( )
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:158:34: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]
  158 |       {mcol->length() / col_num, col_num}, options);
      |                                  ^~~~~~~
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:158:34: note: insert an explicit cast to silence this issue
  158 |       {mcol->length() / col_num, col_num}, options);
      |                                  ^~~~~~~
      |                                  static_cast<long long>( )
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:163:8: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]
  163 |       {mcol->length() / col_num, col_num}, options);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:163:8: note: insert an explicit cast to silence this issue
  163 |       {mcol->length() / col_num, col_num}, options);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
      |        static_cast<long long>( )
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:163:34: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]
  163 |       {mcol->length() / col_num, col_num}, options);
      |                                  ^~~~~~~
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:163:34: note: insert an explicit cast to silence this issue
  163 |       {mcol->length() / col_num, col_num}, options);
      |                                  ^~~~~~~
      |                                  static_cast<long long>( )
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:168:8: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]
  168 |       {mcol->length() / col_num, col_num}, options);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:168:8: note: insert an explicit cast to silence this issue
  168 |       {mcol->length() / col_num, col_num}, options);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
      |        static_cast<long long>( )
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:168:34: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]
  168 |       {mcol->length() / col_num, col_num}, options);
      |                                  ^~~~~~~
/Users/runner/work/GraphScope/GraphScope/learning_engine/graphlearn-for-pytorch/graphlearn_torch/v6d/vineyard_utils.cc:168:34: note: insert an explicit cast to silence this issue
  168 |       {mcol->length() / col_num, col_num}, options);
      |                                  ^~~~~~~
      |                                  static_cast<long long>( )
```