### PR TITLE
Support two-stage partitioning

### DIFF
--- a/examples/igbh/README.md
+++ b/examples/igbh/README.md
@@ -44,9 +44,31 @@ CUDA_VISIBLE_DEVICES=0,1 python train_rgnn_multi_gpu.py --model='rgat' --dataset
 ## 3. Distributed (multi nodes) examples
 
 We use 2 nodes as an example.
+
 ### 3.1 Data partitioning
+
+To partition the dataset (including both the topology and feature):
 ```
 python partition.py --dataset_size='tiny' --num_partitions=2 --num_classes=19
+```
+
+GLT also supports two-stage partitioning, which splits the process of topology 
+partitioning and feature partitioning. After the topology partitioning is executed,
+the feature partitioning process can be conducted in each training node in parallel 
+to speedup the partitioning.
+
+The topology partitioning is conducted by setting  `--with_feature=0`:
+```
+python partition.py --dataset_size='tiny' --num_partitions=2 --num_classes=19 --with_feature=0
+```
+
+The feature partitioning in conducted in each training node:
+```
+# node 0 which holds partition 0:
+python build_partition_feature.py --dataset_size='tiny' --in_memory=0 --partition_idx=0
+
+# node 1 which holds partition 1:
+python build_partition_feature.py --dataset_size='tiny' --in_memory=0 --partition_idx=1
 ```
 
 ### 3.2 Example of distributed training

--- a/examples/igbh/partition.py
+++ b/examples/igbh/partition.py
@@ -29,7 +29,8 @@ def partition_dataset(src_path: str,
                       dataset_size: str='tiny',
                       in_memory: bool=True,
                       edge_assign_strategy: str='by_src',
-                      use_label_2K: bool=False):
+                      use_label_2K: bool=False,
+                      with_feature: bool=True):
   print(f'-- Loading igbh_{dataset_size} ...')
   data = IGBHeteroDataset(src_path, dataset_size, in_memory, use_label_2K)
   node_num = {k : v.shape[0] for k, v in data.feat_dict.items()}
@@ -80,7 +81,7 @@ def partition_dataset(src_path: str,
     edge_assign_strategy=edge_assign_strategy,
     chunk_size=chunk_size,
   )
-  partitioner.partition()
+  partitioner.partition(with_feature)
 
 
 if __name__ == '__main__':
@@ -104,6 +105,8 @@ if __name__ == '__main__':
       help="Chunk size for feature partitioning.")
   parser.add_argument("--edge_assign_strategy", type=str, default='by_src',
       help="edge assign strategy can be either 'by_src' or 'by_dst'")
+  parser.add_argument("--with_feature", action="store_true",
+      help="use trim_to_layer function from pyG")
 
   args = parser.parse_args()
 
@@ -116,4 +119,5 @@ if __name__ == '__main__':
     in_memory=args.in_memory,
     edge_assign_strategy=args.edge_assign_strategy,
     use_label_2K=args.num_classes==2983,
+    with_feature=args.with_feature
   )

--- a/examples/igbh/partition.py
+++ b/examples/igbh/partition.py
@@ -105,8 +105,8 @@ if __name__ == '__main__':
       help="Chunk size for feature partitioning.")
   parser.add_argument("--edge_assign_strategy", type=str, default='by_src',
       help="edge assign strategy can be either 'by_src' or 'by_dst'")
-  parser.add_argument("--with_feature", action="store_true",
-      help="use trim_to_layer function from pyG")
+  parser.add_argument('--with_feature', type=int, default=1,
+      choices=[0, 1], help='0:do not partition feature, 1:partition feature')
 
   args = parser.parse_args()
 
@@ -119,5 +119,5 @@ if __name__ == '__main__':
     in_memory=args.in_memory,
     edge_assign_strategy=args.edge_assign_strategy,
     use_label_2K=args.num_classes==2983,
-    with_feature=args.with_feature
+    with_feature=args.with_feature==1
   )


### PR DESCRIPTION
1. Fix the error of "path already exists in partitioning"
2. Add the support of two-stage partitioning, which splits the process of topology partitioning and feature partitioning. After the topology partitioning is executed, the feature partitioning process can be conducted in each training node in parallel to speedup the partitioning.