### PR TITLE
Fix GPU allocation while splitting training and sampling in distributed training

### DIFF
--- a/examples/igbh/dist_train_rgnn.py
+++ b/examples/igbh/dist_train_rgnn.py
@@ -74,12 +74,12 @@ def run_training_proc(local_proc_rank, num_nodes, node_rank, num_training_procs,
 
   current_ctx = glt.distributed.get_context()
   if with_gpu:
-    current_device = torch.device(local_proc_rank % torch.cuda.device_count())
+    current_device = torch.device((local_proc_rank * 2) % torch.cuda.device_count())
   else:
     current_device = torch.device('cpu')
   
   if split_training_sampling:
-    sampling_device = torch.device((local_proc_rank + 1) % torch.cuda.device_count())
+    sampling_device = torch.device((local_proc_rank * 2 + 1) % torch.cuda.device_count())
   else: 
     sampling_device = current_device
 


### PR DESCRIPTION
Fix card allocation while splitting training and sampling in distributed training, now the GPUs are averagely assigned for sampling and training.