### PR TITLE
Separate features entirely from GLT Dataset

### DIFF
--- a/examples/igbh/train_rgnn_multi_gpu.py
+++ b/examples/igbh/train_rgnn_multi_gpu.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Alibaba Group Holding Limited. All Rights Reserved.
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR separates the features entirely from GLT Dataset object. From our local testing, this shows 2x speedup on 3-layer models compared to not pinning the features on GLT Dataset object. 

The following data are gathered on hyperparameter (all other remains default): 
- Dataset: in-memory FP16 IGBH-Small
- GPU: 1x2 A6000
- Local batch size: 512 
- Fanout: 15,10,5; Number of layers: 3
- Learning rate: 0.001
- Epochs: 3

When using vanilla GLT training **with** `pin_feature`, the per-epoch time is 4min 44s, total time 14min 6s: 
![image](https://github.com/alibaba/graphlearn-for-pytorch/assets/46603306/39c3cb91-f235-4013-82d6-e456ae2ee57b)

When using **this workaround**, the per-epoch time is 5min 55s, total time 17min 42s:
![image](https://github.com/alibaba/graphlearn-for-pytorch/assets/46603306/71e43f7f-7388-43a4-b241-2b42f8811850)

When using GLT training **without** `pin_feature`, the per-epoch time is 10min 52s, total time 32min 33s: 
![image](https://github.com/alibaba/graphlearn-for-pytorch/assets/46603306/98e706dd-0d58-4e6d-995e-07dcb964871c)
