### PR TITLE
Refine IGBH preprocessing

### DIFF
--- a/examples/igbh/README.md
+++ b/examples/igbh/README.md
@@ -45,21 +45,22 @@ CUDA_VISIBLE_DEVICES=0,1 python train_rgnn_multi_gpu.py --model='rgat' --dataset
 ```
 
 Note that the original graph is in COO fornat, the above scripts will transform
-the graph from COO to CSC or CSR according to the edge direction of sampling. This process
-is time consuming when the graph is large. We provide a script to convert and persist
-the graph in CSC or CSR format:
+the graph from COO to CSC or CSR according to the edge direction of sampling. 
+If `--use_fp16` is enabled, the feature will be converted from `fp32`into `fp16`. 
+This process could be time consuming. We provide a script to convert and persist
+the graph layout (from `COO` to `CSC` or `CSR`) and the data type of feature:
 ```
-python compress_graph.py --dataset_size='tiny' --layout='CSC'
+python compress_graph.py --dataset_size='tiny' --layout='CSC' --use_fp16
 ```
 
-Once the CSC or CSR is persisted, train the model with `--cpu_mode='CSC'`
-or `--cpu_mode='CSR'`.
+Once the conversion is completed, train the model:
 
 ```
 CUDA_VISIBLE_DEVICES=0,1 python train_rgnn_multi_gpu.py --model='rgat' --dataset_size='tiny' --num_classes=19 --use_fp16 --layout='CSC'
 ```
 
-Note that, when the sampling edge direction is `in`, the layout should be `CSC`. When the sampling edge direction is `out`, the layout should be `CSR`.
+Note that, when the sampling edge direction is `in`, the layout should be `CSC`. 
+When the sampling edge direction is `out`, the layout should be `CSR`.
 
 
 ## 3. Distributed (multi nodes) examples

--- a/examples/igbh/build_partition_feature.py
+++ b/examples/igbh/build_partition_feature.py
@@ -17,6 +17,7 @@ import argparse
 import os.path as osp
 
 import graphlearn_torch as glt
+import torch
 
 from dataset import IGBHeteroDataset
 
@@ -33,7 +34,12 @@ def partition_feature(src_path: str,
 
   print(f'-- Build feature for partition {partition_idx} ...')
   dst_path = osp.join(dst_path, f'{dataset_size}-partitions')
-  glt.partition.base.build_partition_feature(dst_path, partition_idx, chunk_size, data.feat_dict)
+  node_feat_dtype = torch.float16 if use_fp16 else torch.float32
+  glt.partition.base.build_partition_feature(root_dir = dst_path,
+                                             partition_idx = partition_idx,
+                                             chunk_size = chunk_size,
+                                             node_feat = data.feat_dict,
+                                             node_feat_dtype = node_feat_dtype)
 
 
 if __name__ == '__main__':

--- a/examples/igbh/compress_graph.py
+++ b/examples/igbh/compress_graph.py
@@ -99,7 +99,7 @@ class IGBHeteroDatasetCompress(object):
 
     for etype in self.etypes:
       graph = glt_dataset.get_graph(etype)
-      indptr, indices = graph.export_topology()
+      indptr, indices, _ = graph.export_topology()
       path = os.path.join(self.dir, self.dataset_size, 'processed', self.layout, compress_edge_dict[etype])
       if not os.path.exists(path):
         os.makedirs(path)

--- a/examples/igbh/compress_graph.py
+++ b/examples/igbh/compress_graph.py
@@ -19,6 +19,7 @@ import os.path as osp
 
 import graphlearn_torch as glt
 
+from dataset import float2half
 from download import download_dataset
 from torch_geometric.utils import add_self_loops, remove_self_loops
 from typing import Literal
@@ -119,9 +120,14 @@ if __name__ == '__main__':
       choices=['tiny', 'small', 'medium', 'large', 'full'],
       help='size of the datasets')
   parser.add_argument("--layout", type=str, default='CSC')
+  parser.add_argument('--use_fp16', action="store_true",
+    help="convert the node/edge feature into fp16 format")
   args = parser.parse_args()
   print(f"Start constructing the {args.layout} graph...")
   igbh_dataset = IGBHeteroDatasetCompress(args.path, args.dataset_size, args.layout)
+  if args.use_fp16:
+    base_path = osp.join(args.path, args.dataset_size, 'processed')
+    float2half(base_path, args.dataset_size)
   
 
 

--- a/examples/igbh/dataset.py
+++ b/examples/igbh/dataset.py
@@ -23,6 +23,66 @@ from torch_geometric.utils import add_self_loops, remove_self_loops
 from download import download_dataset
 from typing import Literal
 
+def float2half(base_path, dataset_size):
+  paper_nodes_num = {'tiny':100000, 'small':1000000, 'medium':10000000, 'large':100000000, 'full':269346174}
+  author_nodes_num = {'tiny':357041, 'small':1926066, 'medium':15544654, 'large':116959896, 'full':277220883}
+  # paper node
+  paper_feat_path = osp.join(base_path, 'paper', 'node_feat.npy')
+  paper_fp16_feat_path = osp.join(base_path, 'paper', 'node_feat_fp16.pt')
+  if not osp.exists(paper_fp16_feat_path):
+    if dataset_size in ['large', 'full']:
+      num_paper_nodes = paper_nodes_num[dataset_size]
+      paper_node_features = torch.from_numpy(np.memmap(paper_feat_path, dtype='float32', mode='r', shape=(num_paper_nodes,1024)))
+    else:
+      paper_node_features = torch.from_numpy(np.load(paper_feat_path, mmap_mode='r'))
+    paper_node_features = paper_node_features.half()
+    torch.save(paper_node_features, paper_fp16_feat_path)
+
+  # author node
+  author_feat_path = osp.join(base_path, 'author', 'node_feat.npy')
+  author_fp16_feat_path = osp.join(base_path, 'author', 'node_feat_fp16.pt')
+  if not osp.exists(author_fp16_feat_path):
+    if dataset_size in ['large', 'full']:
+      num_author_nodes = author_nodes_num[dataset_size]
+      author_node_features = torch.from_numpy(np.memmap(author_feat_path, dtype='float32', mode='r', shape=(num_author_nodes,1024)))
+    else:
+      author_node_features = torch.from_numpy(np.load(author_feat_path, mmap_mode='r'))
+    author_node_features = author_node_features.half()
+    torch.save(author_node_features, author_fp16_feat_path)
+
+  # institute node
+  institute_feat_path = osp.join(base_path, 'institute', 'node_feat.npy')
+  institute_fp16_feat_path = osp.join(base_path, 'institute', 'node_feat_fp16.pt')
+  if not osp.exists(institute_fp16_feat_path):
+    institute_node_features = torch.from_numpy(np.load(institute_feat_path, mmap_mode='r'))
+    institute_node_features = institute_node_features.half()
+    torch.save(institute_node_features, institute_fp16_feat_path)
+
+  # fos node
+  fos_feat_path = osp.join(base_path, 'fos', 'node_feat.npy')
+  fos_fp16_feat_path = osp.join(base_path, 'fos', 'node_feat_fp16.pt')
+  if not osp.exists(fos_fp16_feat_path):
+    fos_node_features = torch.from_numpy(np.load(fos_feat_path, mmap_mode='r'))
+    fos_node_features = fos_node_features.half()
+    torch.save(fos_node_features, fos_fp16_feat_path)
+    
+  if dataset_size in ['large', 'full']:
+    # conference node
+    conference_feat_path = osp.join(base_path, 'conference', 'node_feat.npy')
+    conference_fp16_feat_path = osp.join(base_path, 'conference', 'node_feat_fp16.pt')
+    if not osp.exists(conference_fp16_feat_path):
+      conference_node_features = torch.from_numpy(np.load(conference_feat_path, mmap_mode='r'))
+      conference_node_features = conference_node_features.half()
+      torch.save(conference_node_features, conference_fp16_feat_path)
+
+    # journal node
+    journal_feat_path = osp.join(base_path, 'journal', 'node_feat.npy')
+    journal_fp16_feat_path = osp.join(base_path, 'journal', 'node_feat_fp16.pt')
+    if not osp.exists(journal_fp16_feat_path):
+      journal_node_features = torch.from_numpy(np.load(journal_feat_path, mmap_mode='r'))
+      journal_node_features = journal_node_features.half()
+      torch.save(journal_node_features, journal_fp16_feat_path)
+
 class IGBHeteroDataset(object):
   def __init__(self,
                path,
@@ -55,66 +115,8 @@ class IGBHeteroDataset(object):
     if not osp.exists(self.base_path):
       download_dataset(path, 'heterogeneous', dataset_size)
     if self.use_fp16:
-      self.float2half()
+      float2half(self.base_path, self.dataset_size)
     self.process()
-
-  def float2half(self):
-    # paper node
-    paper_feat_path = osp.join(self.base_path, 'paper', 'node_feat.npy')
-    paper_fp16_feat_path = osp.join(self.base_path, 'paper', 'node_feat_fp16.pt')
-    if not osp.exists(paper_fp16_feat_path):
-      if self.dataset_size in ['large', 'full']:
-        num_paper_nodes = self.paper_nodes_num[self.dataset_size]
-        paper_node_features = torch.from_numpy(np.memmap(paper_feat_path, dtype='float32', mode='r', shape=(num_paper_nodes,1024)))
-      else:
-        paper_node_features = torch.from_numpy(np.load(paper_feat_path, mmap_mode='r'))
-      paper_node_features = paper_node_features.half()
-      torch.save(paper_node_features, paper_fp16_feat_path)
-
-    # author node
-    author_feat_path = osp.join(self.base_path, 'author', 'node_feat.npy')
-    author_fp16_feat_path = osp.join(self.base_path, 'author', 'node_feat_fp16.pt')
-    if not osp.exists(author_fp16_feat_path):
-      if self.dataset_size in ['large', 'full']:
-        num_author_nodes = self.author_nodes_num[self.dataset_size]
-        author_node_features = torch.from_numpy(np.memmap(author_feat_path, dtype='float32', mode='r', shape=(num_author_nodes,1024)))
-      else:
-        author_node_features = torch.from_numpy(np.load(author_feat_path, mmap_mode='r'))
-      author_node_features = author_node_features.half()
-      torch.save(author_node_features, author_fp16_feat_path)
-
-    # institute node
-    institute_feat_path = osp.join(self.base_path, 'institute', 'node_feat.npy')
-    institute_fp16_feat_path = osp.join(self.base_path, 'institute', 'node_feat_fp16.pt')
-    if not osp.exists(institute_fp16_feat_path):
-      institute_node_features = torch.from_numpy(np.load(institute_feat_path, mmap_mode='r'))
-      institute_node_features = institute_node_features.half()
-      torch.save(institute_node_features, institute_fp16_feat_path)
-
-    # fos node
-    fos_feat_path = osp.join(self.base_path, 'fos', 'node_feat.npy')
-    fos_fp16_feat_path = osp.join(self.base_path, 'fos', 'node_feat_fp16.pt')
-    if not osp.exists(fos_fp16_feat_path):
-      fos_node_features = torch.from_numpy(np.load(fos_feat_path, mmap_mode='r'))
-      fos_node_features = fos_node_features.half()
-      torch.save(fos_node_features, fos_fp16_feat_path)
-      
-    if self.dataset_size in ['large', 'full']:
-      # conference node
-      conference_feat_path = osp.join(self.base_path, 'conference', 'node_feat.npy')
-      conference_fp16_feat_path = osp.join(self.base_path, 'conference', 'node_feat_fp16.pt')
-      if not osp.exists(conference_fp16_feat_path):
-        conference_node_features = torch.from_numpy(np.load(conference_feat_path, mmap_mode='r'))
-        conference_node_features = conference_node_features.half()
-        torch.save(conference_node_features, conference_fp16_feat_path)
-
-      # journal node
-      journal_feat_path = osp.join(self.base_path, 'journal', 'node_feat.npy')
-      journal_fp16_feat_path = osp.join(self.base_path, 'journal', 'node_feat_fp16.pt')
-      if not osp.exists(journal_fp16_feat_path):
-        journal_node_features = torch.from_numpy(np.load(journal_feat_path, mmap_mode='r'))
-        journal_node_features = journal_node_features.half()
-        torch.save(journal_node_features, journal_fp16_feat_path)
 
   def process(self):
     # load edges

--- a/examples/igbh/dist_train_rgnn.py
+++ b/examples/igbh/dist_train_rgnn.py
@@ -248,12 +248,12 @@ if __name__ == '__main__':
   parser.add_argument('--model', type=str, default='rgat',
                       choices=['rgat', 'rsage'])
   # Model parameters
-  parser.add_argument('--fan_out', type=str, default='15,10,5')
+  parser.add_argument('--fan_out', type=str, default='15,10')
   parser.add_argument('--batch_size', type=int, default=512)
   parser.add_argument('--hidden_channels', type=int, default=128)
-  parser.add_argument('--learning_rate', type=float, default=0.001)
-  parser.add_argument('--epochs', type=int, default=20)
-  parser.add_argument('--num_layers', type=int, default=3)
+  parser.add_argument('--learning_rate', type=float, default=0.01)
+  parser.add_argument('--epochs', type=int, default=1)
+  parser.add_argument('--num_layers', type=int, default=2)
   parser.add_argument('--num_heads', type=int, default=4)
   parser.add_argument('--log_every', type=int, default=2)
   # Distributed settings.
@@ -275,6 +275,8 @@ if __name__ == '__main__':
       help="Only use CPU for sampling and training, default is False.")
   parser.add_argument("--edge_dir", type=str, default='out',
       help="sampling direction, can be 'in' for 'by_dst' or 'out' for 'by_src' for partitions.")
+  parser.add_argument('--layout', type=str, default='COO',
+      help="Layout of input graph: CSC, CSR, COO. Default is COO.")
   parser.add_argument("--rpc_timeout", type=int, default=180,
                       help="rpc timeout in seconds")
   parser.add_argument("--split_training_sampling", action="store_true",
@@ -284,6 +286,7 @@ if __name__ == '__main__':
   parser.add_argument("--use_fp16", action="store_true",
       help="load node/edge feature using fp16 format to reduce memory usage")
   args = parser.parse_args()
+  assert args.layout in ['COO', 'CSC', 'CSR']
   # when set --cpu_mode or GPU is not available, use cpu only mode.
   args.with_gpu = (not args.cpu_mode) and torch.cuda.is_available()
   if args.with_gpu:
@@ -298,6 +301,7 @@ if __name__ == '__main__':
     root_dir=osp.join(args.path, f'{args.dataset_size}-partitions'),
     partition_idx=data_pidx,
     graph_mode='ZERO_COPY' if args.with_gpu else 'CPU',
+    input_layout = args.layout,
     feature_with_gpu=args.with_gpu,
     whole_node_label_file={'paper': osp.join(args.path, f'{args.dataset_size}-label', 'label.pt')}
   )

--- a/examples/igbh/partition.py
+++ b/examples/igbh/partition.py
@@ -22,7 +22,6 @@ import torch
 from dataset import IGBHeteroDataset
 from typing import Literal
 
-
 def partition_dataset(src_path: str,
                       dst_path: str,
                       num_partitions: int,
@@ -33,7 +32,7 @@ def partition_dataset(src_path: str,
                       use_label_2K: bool=False,
                       with_feature: bool=True,
                       use_fp16: bool=False,
-                      layout: Literal['CSC', 'CSR', 'COO'] = 'CSC'):
+                      layout: Literal['CSC', 'CSR', 'COO'] = 'COO'):
   print(f'-- Loading igbh_{dataset_size} ...')
   data = IGBHeteroDataset(src_path, dataset_size, in_memory, use_label_2K, use_fp16=use_fp16)
   node_num = {k : v.shape[0] for k, v in data.feat_dict.items()}
@@ -117,7 +116,7 @@ def partition_dataset(src_path: str,
 
       for etype in graph_dict:
         graph = dataset.get_graph(etype)
-        indptr, indices = graph.export_topology()
+        indptr, indices, _ = graph.export_topology()
         path = osp.join(base_path, compress_edge_dict[etype])
         if layout == 'CSR':
           torch.save(indptr, osp.join(path, 'rows.pt'))
@@ -125,7 +124,6 @@ def partition_dataset(src_path: str,
         else:
           torch.save(indptr, osp.join(path, 'cols.pt'))
           torch.save(indices, osp.join(path, 'rows.pt'))
-
 
 if __name__ == '__main__':
   root = osp.join(osp.dirname(osp.dirname(osp.dirname(osp.realpath(__file__)))), 'data', 'igbh')
@@ -152,7 +150,7 @@ if __name__ == '__main__':
       choices=[0, 1], help='0:do not partition feature, 1:partition feature')
   parser.add_argument('--use_fp16', action="store_true",
       help="save partitioned node/edge feature into fp16 format")
-  parser.add_argument("--layout", type=str, default='CSC', 
+  parser.add_argument("--layout", type=str, default='COO', 
       help="layout of the partitioned graph: CSC, CSR, COO")
 
   args = parser.parse_args()

--- a/examples/igbh/partition.py
+++ b/examples/igbh/partition.py
@@ -20,6 +20,7 @@ import graphlearn_torch as glt
 import torch
 
 from dataset import IGBHeteroDataset
+from typing import Literal
 
 
 def partition_dataset(src_path: str,
@@ -31,7 +32,8 @@ def partition_dataset(src_path: str,
                       edge_assign_strategy: str='by_src',
                       use_label_2K: bool=False,
                       with_feature: bool=True,
-                      use_fp16: bool=False):
+                      use_fp16: bool=False,
+                      layout: Literal['CSC', 'CSR', 'COO'] = 'CSC'):
   print(f'-- Loading igbh_{dataset_size} ...')
   data = IGBHeteroDataset(src_path, dataset_size, in_memory, use_label_2K, use_fp16=use_fp16)
   node_num = {k : v.shape[0] for k, v in data.feat_dict.items()}
@@ -73,10 +75,56 @@ def partition_dataset(src_path: str,
     num_nodes=node_num,
     edge_index=data.edge_dict,
     node_feat=data.feat_dict,
+    node_feat_dtype = torch.float16 if use_fp16 else torch.float32,
     edge_assign_strategy=edge_assign_strategy,
     chunk_size=chunk_size,
   )
   partitioner.partition(with_feature)
+
+  if layout in ['CSC', 'CSR']:
+    compress_edge_dict = {}
+    compress_edge_dict[('paper', 'cites', 'paper')] = 'paper__cites__paper'
+    compress_edge_dict[('paper', 'written_by', 'author')] = 'paper__written_by__author'
+    compress_edge_dict[('author', 'affiliated_to', 'institute')] = 'author__affiliated_to__institute'
+    compress_edge_dict[('paper', 'topic', 'fos')] = 'paper__topic__fos'
+    compress_edge_dict[('author', 'rev_written_by', 'paper')] = 'author__rev_written_by__paper'
+    compress_edge_dict[('institute', 'rev_affiliated_to', 'author')] = 'institute__rev_affiliated_to__author'
+    compress_edge_dict[('fos', 'rev_topic', 'paper')] = 'fos__rev_topic__paper'
+    compress_edge_dict[('paper', 'published', 'journal')] = 'paper__published__journal'
+    compress_edge_dict[('paper', 'venue', 'conference')] = 'paper__venue__conference'
+    compress_edge_dict[('journal', 'rev_published', 'paper')] = 'journal__rev_published__paper'
+    compress_edge_dict[('conference', 'rev_venue', 'paper')] = 'conference__rev_venue__paper'
+
+    for pidx in range(num_partitions):
+      base_path = osp.join(dst_path, f'{dataset_size}-partitions', f'part{pidx}', 'graph')
+      device = torch.device('cpu')
+      graph_dict = {}
+      for etype, e_path in compress_edge_dict.items():
+        graph = glt.partition.base.load_graph_partition_data(osp.join(base_path, e_path), device)
+        if graph != None:
+          graph_dict[etype] = graph
+      
+      edge_dir = 'out' if layout == 'CSR' else 'in'
+      dataset = glt.distributed.DistDataset(edge_dir=edge_dir)
+      edge_index, edge_ids, edge_weights = {}, {}, {}
+      for k, v in graph_dict.items():
+        edge_index[k] = v.edge_index
+        edge_ids[k] = v.eids
+        edge_weights[k] = v.weights 
+      # COO is the oroginal layout of raw igbh graph
+      dataset.init_graph(edge_index, edge_ids, edge_weights, layout='COO',
+        graph_mode='CPU', device=device)
+
+      for etype in graph_dict:
+        graph = dataset.get_graph(etype)
+        indptr, indices = graph.export_topology()
+        path = osp.join(base_path, compress_edge_dict[etype])
+        if layout == 'CSR':
+          torch.save(indptr, osp.join(path, 'rows.pt'))
+          torch.save(indices, osp.join(path, 'cols.pt'))
+        else:
+          torch.save(indptr, osp.join(path, 'cols.pt'))
+          torch.save(indices, osp.join(path, 'rows.pt'))
 
 
 if __name__ == '__main__':
@@ -104,6 +152,8 @@ if __name__ == '__main__':
       choices=[0, 1], help='0:do not partition feature, 1:partition feature')
   parser.add_argument('--use_fp16', action="store_true",
       help="save partitioned node/edge feature into fp16 format")
+  parser.add_argument("--layout", type=str, default='CSC', 
+      help="layout of the partitioned graph: CSC, CSR, COO")
 
   args = parser.parse_args()
 
@@ -117,5 +167,6 @@ if __name__ == '__main__':
     edge_assign_strategy=args.edge_assign_strategy,
     use_label_2K=args.num_classes==2983,
     with_feature=args.with_feature==1,
-    use_fp16=args.use_fp16
+    use_fp16=args.use_fp16,
+    layout = args.layout
   )

--- a/graphlearn_torch/python/data/graph.py
+++ b/graphlearn_torch/python/data/graph.py
@@ -252,7 +252,7 @@ class Graph(object):
                          f"invalid mode {self.mode}")
 
   def export_topology(self):
-    return self.topo.indptr, self.topo.indices
+    return self.topo.indptr, self.topo.indices, self.topo.edge_ids
 
   def share_ipc(self):
     r""" Create ipc handle for multiprocessing.

--- a/graphlearn_torch/python/distributed/dist_dataset.py
+++ b/graphlearn_torch/python/distributed/dist_dataset.py
@@ -82,6 +82,7 @@ class DistDataset(Dataset):
     root_dir: str,
     partition_idx: int,
     graph_mode: str = 'ZERO_COPY',
+    input_layout: Literal['COO', 'CSR', 'CSC'] = 'COO',
     feature_with_gpu: bool = True,
     device_group_list: Optional[List[DeviceGroup]] = None,
     whole_node_label_file: Union[str, Dict[NodeType, str]] = None,
@@ -94,8 +95,10 @@ class DistDataset(Dataset):
       root_dir (str): The directory path to load the graph and feature
         partition data.
       partition_idx (int): Partition idx to load.
-      graph_mode (str): Mode for creating graphlearn_torch's `Graph`, including
-        'CPU', 'ZERO_COPY' or 'CUDA'. (default: 'ZERO_COPY')
+      graph_mode (str): Mode for creating graphlearn_torch's ``Graph``, including
+        ``CPU``, ``ZERO_COPY`` or ``CUDA``. (default: ``ZERO_COPY``)
+      input_layout (str): layout of the input graph, including ``CSR``, ``CSC`` 
+        or ``COO``. (default: ``COO``)
       feature_with_gpu (bool): A Boolean value indicating whether the created
         ``Feature`` objects of node/edge features use ``UnifiedTensor``.
         If True, it means ``Feature`` consists of ``UnifiedTensor``, otherwise
@@ -135,7 +138,7 @@ class DistDataset(Dataset):
       edge_index = graph_data.edge_index
       edge_ids = graph_data.eids
       edge_weights = graph_data.weights
-    self.init_graph(edge_index, edge_ids, edge_weights, layout='COO',
+    self.init_graph(edge_index, edge_ids, edge_weights, layout=input_layout,
                     graph_mode=graph_mode, device=device)
 
     # load node feature partition


### PR DESCRIPTION
1. For both single-node and distributed training, use separate scripts for the conversion processes of graph layout and feature data type.
2. Fix the device assignment bug when sampling and training are using the same GPU in distributed training.