### PR TITLE
use oneCycleLR scheduler to fine tune model optimizer

### DIFF
--- a/examples/igbh/dist_train_rgnn.py
+++ b/examples/igbh/dist_train_rgnn.py
@@ -16,7 +16,6 @@
 import argparse, datetime
 import os.path as osp
 import time, tqdm
-import math
 
 import graphlearn_torch as glt
 import mlperf_logging.mllog.constants as mllog_constants
@@ -207,10 +206,9 @@ def run_training_proc(local_proc_rank, num_nodes, node_rank, num_training_procs,
 
   loss_fcn = torch.nn.CrossEntropyLoss().to(current_device)
   optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
-  if use_oneCycleLR_scheduler:
-    epoch_steps = math.ceil(train_idx.numel()/batch_size)
-    scheduler = torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr=learning_rate, steps_per_epoch=epoch_steps, epochs=epochs)
   batch_num = (len(train_idx) + batch_size - 1) // batch_size
+  if use_oneCycleLR_scheduler:
+    scheduler = torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr=learning_rate, steps_per_epoch=batch_num, epochs=epochs)
   validation_freq = int(batch_num * validation_frac_within_epoch)
   is_success = False
   epoch_num = 0


### PR DESCRIPTION
With the help of this optimizer scheduler and large learning rate, we can get higher accuracy when using large batch size to do the distributed training. Experiment shows we can get 72.15 for 16 partitions igbh-full training with local bs=4096, which can help us drop the epoch time from 18 hours to 12 hours. Attached is the experiment results:


<img width="669" alt="image" src="https://github.com/alibaba/graphlearn-for-pytorch/assets/13268042/dbfc8798-3598-41c9-80b8-befffee54488">

























































































