### PR TITLE
fix: data path for s/c case

### DIFF
--- a/examples/distributed/server_client_mode/sage_supervised_client.py
+++ b/examples/distributed/server_client_mode/sage_supervised_client.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
   parser.add_argument(
     "--dataset_root_dir",
     type=str,
-    default='../../data/products',
+    default='../../../data/products',
     help="The root directory (relative path) of partitioned ogbn dataset.",
   )
   parser.add_argument(

--- a/examples/distributed/server_client_mode/sage_supervised_server.py
+++ b/examples/distributed/server_client_mode/sage_supervised_server.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
   parser.add_argument(
     "--dataset_root_dir",
     type=str,
-    default='../../data/products',
+    default='../../../data/products',
     help="The root directory (relative path) of partitioned ogbn dataset.",
   )
   parser.add_argument(


### PR DESCRIPTION
directory 'data' is under the 'graphlearn-for-pytorch', so the default --dataset_root_dir should be '../../../data/products'