### PR TITLE
[Bug Fix] Update `dist_neighbor_sampler` to handle heterogeneous case where node labels is None

### DIFF
--- a/graphlearn_torch/python/distributed/dist_neighbor_sampler.py
+++ b/graphlearn_torch/python/distributed/dist_neighbor_sampler.py
@@ -182,7 +182,7 @@ class DistNeighborSampler(ConcurrentEventLoop):
             local_only=False, rpc_router=self.rpc_router, device=self.device
           )
       else:
-        assert isinstance(self.dist_node_labels, Dict)
+        assert self.dist_node_labels is None or isinstance(self.dist_node_labels, Dict)
         if self.dist_node_labels is not None and \
             all(isinstance(value, Feature) for value in self.dist_node_labels.values()):
           self.dist_node_labels = DistFeature(


### PR DESCRIPTION
This PR aims to fix `dist_neighbor_sampler` which fails in the heterogeneous case when `self.dist_node_labels=None`. There is an assert statement which enforces this field to be a dictionary, but the subsequent line implies that we should be allowing for this to also be None:
```
if self.dist_node_labels is not None and all(isinstance(value, Feature) for value in self.dist_node_labels.values()):
```
