### PR TITLE
Set `DistLoader._shutdowned` to the beginning of `__init__`

### DIFF
--- a/graphlearn_torch/python/distributed/dist_loader.py
+++ b/graphlearn_torch/python/distributed/dist_loader.py
@@ -122,6 +122,8 @@ class DistLoader(object):
     self.sampling_config = sampling_config
     self.to_device = get_available_device(to_device)
     self.worker_options = worker_options
+    self._shutdowned = False
+
     if self.worker_options is None:
       self.worker_options = CollocatedDistSamplingWorkerOptions()
 
@@ -258,7 +260,6 @@ class DistLoader(object):
           f"worker options type '{type(worker_options)}'"
         )
 
-    self._shutdowned = False
 
   def __del__(self):
     if python_exit_status is True or python_exit_status is None:


### PR DESCRIPTION
If we don't do this, and something throws in the constructor (ex [1]), then when `__del__` is called, and `self.shutdown()` is called, we wont have the `self._shutdowned` property of the object set and we throw like:

```
ERROR
Exception ignored in: <function DistLoader.__del__ at 0x7fd15dba0040>
Traceback (most recent call last):
  File "/site-packages/graphlearn_torch/distributed/dist_loader.py", line 266, in __del__
    self.shutdown()
  File "/graphlearn_torch/distributed/dist_loader.py", line 269, in shutdown
    if self._shutdowned:
AttributeError: 'DistNeighborLoader' object has no attribute '_shutdowned'
```

[1]: https://github.com/alibaba/graphlearn-for-pytorch/blob/main/graphlearn_torch/python/distributed/dist_loader.py#L150-L153