### PR TITLE
Enable sampling multiple nodes per "example"

### DIFF
--- a/graphlearn_torch/python/sampler/base.py
+++ b/graphlearn_torch/python/sampler/base.py
@@ -60,10 +60,10 @@ class NodeSamplerInput(CastMixin):
     if not isinstance(index, torch.Tensor):
       index = torch.tensor(index, dtype=torch.long)
     index = index.to(self.node.device)
-    return NodeSamplerInput(self.node[index], self.input_type)
+    return NodeSamplerInput(self.node[index].view(-1), self.input_type)
 
   def __len__(self):
-    return self.node.numel()
+    return self.node.shape[0]
 
   def share_memory(self):
     self.node.share_memory_()

--- a/test/python/test_sampler_base.py
+++ b/test/python/test_sampler_base.py
@@ -1,0 +1,59 @@
+import unittest
+
+import torch
+from torch.testing import assert_close
+
+from graphlearn_torch.sampler.base import NodeSamplerInput
+
+
+def _assert_tensor_equal(tensor1, tensor2):
+    assert_close(tensor1, tensor2, rtol=0, atol=0)
+
+
+class TestSamplerBase(unittest.TestCase):
+
+    def test_node_sampler_input_int_index(self):
+        input_data = NodeSamplerInput(node=torch.arange(10))
+        _assert_tensor_equal(input_data[0].node, torch.tensor([0]))
+
+    def test_node_sampler_input_tensor_index(self):
+        input_data = NodeSamplerInput(node=torch.arange(10))
+        with self.subTest("scalar tensor input"):
+            _assert_tensor_equal(input_data[torch.tensor(0)].node, torch.tensor([0]))
+
+        with self.subTest("slice tensor input"):
+            _assert_tensor_equal(input_data[torch.tensor([0, 1])].node, torch.tensor([0, 1]))
+
+    def test_node_sampler_input_multiple_examples(self):
+        input_data = NodeSamplerInput(node=torch.tensor([[0, 1, 2], [3, 4, 5]]))
+        self.assertEqual(len(input_data), 2)
+
+        with self.subTest("scalar tensor input"):
+            _assert_tensor_equal(input_data[torch.tensor(0)].node, torch.tensor([0, 1, 2]))
+
+        with self.subTest("slice tensor input"):
+            _assert_tensor_equal(
+                input_data[torch.tensor([0, 1])].node, torch.tensor([0, 1, 2, 3, 4, 5])
+            )
+
+        # Also test with dataloader - since that's how we actually use this
+        with self.subTest("dataloader"):
+            loader = torch.utils.data.DataLoader(torch.arange(2))
+            expected_data = torch.tensor([[0, 1, 2], [3, 4, 5]])
+
+            self.assertEqual(len(loader), len(expected_data))
+            for data, expected in zip(loader, expected_data):
+                _assert_tensor_equal(input_data[data].node, expected)
+
+        # Also test with dataloader - since that's how we actually use this
+        with self.subTest("dataloader - batched"):
+            loader = torch.utils.data.DataLoader(torch.arange(2), batch_size=2)
+            expected_data = torch.tensor([[0, 1, 2, 3, 4, 5]])
+
+            self.assertEqual(len(loader), len(expected_data))
+            for data, expected in zip(loader, expected_data):
+                _assert_tensor_equal(input_data[data].node, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We have a use case where we'd like to sample against multiple nodes at the same time. For instance, we'd like to generate subgraphs for both `A` and `B` in the below graph.

![image](https://github.com/user-attachments/assets/082ec439-2d20-492c-a281-1752975dd122)

I'd like to be able to specify that input_nodes = `[[A, B], [C, D]]` as inputs to `DistNeighborLoader` [1] so that we sample against `A, B` for one example and `B, C` for another example.

While it is possible to achieve the same functionality via batching, I feel like it will be very tedious to keep track of both the "example count" and "batch size" and how they interplay.
Additionally, if we must batch here, then we would need to construct our `input_nodes` very carefully, which I feel is also quite error prone.

Without this change, when we are iterating through the `NodeSamplerInput` in `_sampling_worker_loop` [2],  if we have something like `NodeSamplerInput([[0, 1], [2, 3]])` then when the dataloader outputs `tensor([0])` we would pass in `tensor([[0, 1]])`, whose shape is (1, 2) to the inducer [3], and the inducer would use `seed_size = tensor([[0, 1]]).size(0) = 1`

I feel like the existing behavior is somewhat surprising, as it essentially means if you pass in a tensor of greater than dim 1, some of your inputs get ignored.

Alternatives:

I considered making it so we could pass in `NodeSamplerInput` (or a subclass) to `DisNeighborLoader` but that seemed quite complicated given that the sampler input has some interplay with the worker options/etc and I wasn't sure how to consolidate all of the types of `input_data` (`input_data: list[RemoteNodeSplitSamplerInput] | RemoteNodeSplitSamplerInput | RemoteNodePathSamplerInput | NodeSamplerInput`) [4]

[1]: https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_neighbor_loader.py#L77
[2]: https://github.com/alibaba/graphlearn-for-pytorch/blob/main/graphlearn_torch/python/distributed/dist_sampling_producer.py#L130-L140
[3]: https://github.com/alibaba/graphlearn-for-pytorch/blob/main/graphlearn_torch/csrc/cpu/inducer.cc#L27
[4]: https://github.com/alibaba/graphlearn-for-pytorch/blob/main/graphlearn_torch/python/distributed/dist_neighbor_loader.py#L117