### PR TITLE
Allow custom `NodeSamplerInput` to be piped into `DistNeighborLoader`

### DIFF
--- a/graphlearn_torch/python/distributed/dist_neighbor_loader.py
+++ b/graphlearn_torch/python/distributed/dist_neighbor_loader.py
@@ -96,7 +96,10 @@ class DistNeighborLoader(DistLoader):
                to_device: Optional[torch.device] = None,
                random_seed: Optional[int] = None,
                worker_options: Optional[AllDistSamplingWorkerOptions] = None):
-
+    if (input_nodes is None) == (node_sampler_input is None):
+      raise ValueError(
+        f"Exactly one of input_nodes or node_sampler_input must be provided. Received input_nodes: {type(input_nodes)}, node_sampler_input: {type(node_sampler_input)}"
+      )
     if isinstance(input_nodes, tuple):
       input_type, input_seeds = input_nodes
     elif input_nodes is not None:

--- a/graphlearn_torch/python/sampler/base.py
+++ b/graphlearn_torch/python/sampler/base.py
@@ -24,6 +24,8 @@ import torch
 from ..typing import NodeType, EdgeType, NumNeighbors, Split
 from ..utils import CastMixin
 
+AllNodeSamplerInputsBase = Union['NodeSamplerInput', 'RemoteNodeSplitSamplerInput', 'RemoteNodePathSamplerInput']
+AllNodeSamplerInputs = Union[AllNodeSamplerInputsBase, List['RemoteNodePathSamplerInput'], List['RemoteNodeSplitSamplerInput']]
 
 class EdgeIndex(NamedTuple):
   r""" PyG's :class:`~torch_geometric.loader.EdgeIndex` used in old data loader


### PR DESCRIPTION
Synced offline with @mkolodner-sc and we do need to provide custom logic for the nodes to sample, so let's go with this instead of https://github.com/alibaba/graphlearn-for-pytorch/pull/155.

We could also pass in some `transform_fn` to the constructor here, that gets called around [1] but that seems more kludgy than this aproach. 

[1]: https://github.com/alibaba/graphlearn-for-pytorch/blob/main/graphlearn_torch/python/distributed/dist_sampling_producer.py#L140C44-L140C57