### PR TITLE
Annotate SamplingConfig.seed as optional

### DIFF
--- a/graphlearn_torch/python/sampler/base.py
+++ b/graphlearn_torch/python/sampler/base.py
@@ -349,7 +349,7 @@ class SamplingConfig:
   with_neg: bool
   with_weight: bool
   edge_dir: Literal['in', 'out']
-  seed: int
+  seed: Optional[int]
 
 
 class BaseSampler(ABC):


### PR DESCRIPTION
This may actually get set as None if you see here [1], [2] 

and this fields usages are gated behind a `is None` check [3] [4]

[1]: https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_neighbor_loader.py#L86
[2]: https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_neighbor_loader.py#L113
[3]: https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_sampling_producer.py#L100-L101
[4]: https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_sampling_producer.py#L199-L200