### PR TITLE
Add sampled input to DistNeighborSampler._sample_from_nodes

### DIFF
--- a/graphlearn_torch/python/distributed/dist_neighbor_sampler.py
+++ b/graphlearn_torch/python/distributed/dist_neighbor_sampler.py
@@ -358,7 +358,7 @@ class DistNeighborSampler(ConcurrentEventLoop):
         num_sampled_nodes=num_sampled_nodes,
         num_sampled_edges=num_sampled_edges,
         input_type=input_type,
-        metadata={}
+        metadata={'input_seeds': input_seeds},
       )
 
     else:
@@ -389,7 +389,7 @@ class DistNeighborSampler(ConcurrentEventLoop):
         batch=batch,
         num_sampled_nodes=num_sampled_nodes,
         num_sampled_edges=num_sampled_edges,
-        metadata={}
+        metadata={'input_seeds': input_seeds},
       )
     # Reclaim inducer into pool.
     self.inducer_pool.put(inducer)

--- a/graphlearn_torch/python/loader/transform.py
+++ b/graphlearn_torch/python/loader/transform.py
@@ -113,21 +113,24 @@ def to_hetero_data(
   # update meta data
   input_type = hetero_sampler_out.input_type
   if isinstance(hetero_sampler_out.metadata, dict):
-    # if edge_dir == 'out', we need to reverse the edge type
-    res_edge_type = reverse_edge_type(input_type) if edge_dir == 'out' else input_type
     for k, v in hetero_sampler_out.metadata.items():
-      if k == 'edge_label_index':
-        if edge_dir == 'out':
-          data[res_edge_type]['edge_label_index'] = \
-            torch.stack((v[1], v[0]), dim=0)
+      if isinstance(input_type, tuple):
+        # if edge_dir == 'out', we need to reverse the edge type
+        res_edge_type = reverse_edge_type(input_type) if edge_dir == 'out' else input_type
+        if k == 'edge_label_index':
+          if edge_dir == 'out':
+            data[res_edge_type]['edge_label_index'] = \
+              torch.stack((v[1], v[0]), dim=0)
+          else:
+            data[res_edge_type]['edge_label_index'] = v
+        elif k == 'edge_label':
+          data[res_edge_type]['edge_label'] = v
+        elif k == 'src_index':
+          data[input_type[0]]['src_index'] = v
+        elif k in ['dst_pos_index', 'dst_neg_index']:
+          data[input_type[-1]][k] = v
         else:
-          data[res_edge_type]['edge_label_index'] = v
-      elif k == 'edge_label':
-        data[res_edge_type]['edge_label'] = v
-      elif k == 'src_index':
-        data[input_type[0]]['src_index'] = v
-      elif k in ['dst_pos_index', 'dst_neg_index']:
-        data[input_type[-1]][k] = v
+          data[k] = v
       else:
         data[k] = v
   elif hetero_sampler_out.metadata is not None:


### PR DESCRIPTION
I want to do this as I'd like to be able to maintain a full copy of the inputs to the sampling function - and AFAICT we do not currently store this anywhere.

My usecase here is that I have some specially constructed tensor which contains labels to sample against, and I'd like to be able to identify the "label nodes". 

The tensor looks something like: `[<src_node>, <padding>, <positive_labels>, ...]`, and since this `.node` and `.batch` get deduped somewhere (idk where) I cannot reconstruct the labels per src node otherwise.

