### PR TITLE
Title: Avoid repeated entropy reads in CPU random sampling

### DIFF
--- a/graphlearn_torch/csrc/cpu/random_sampler.cc
+++ b/graphlearn_torch/csrc/cpu/random_sampler.cc
@@ -141,8 +141,8 @@ void CPURandomSampler::UniformSample(const int64_t* col_begin,
   // with replacement
   const auto cap = col_end - col_begin;
   if (req_num < cap) {
-    uint32_t seed = RandomSeedManager::getInstance().getSeed();
-    thread_local static std::mt19937 engine(seed);
+    thread_local static std::mt19937 engine(
+        RandomSeedManager::getInstance().getSeed());
     std::uniform_int_distribution<> dist(0, cap-1);
     for (int32_t i = 0; i < req_num; ++i) {
       out_nbrs[i] = col_begin[dist(engine)];
@@ -162,8 +162,8 @@ void CPURandomSampler::UniformSample(const int64_t* col_begin,
   // with replacement
   const auto cap = col_end - col_begin;
   if (req_num < cap) {
-    uint32_t seed = RandomSeedManager::getInstance().getSeed();
-    thread_local static std::mt19937 engine(seed);
+    thread_local static std::mt19937 engine(
+        RandomSeedManager::getInstance().getSeed());
     std::uniform_int_distribution<> dist(0, cap-1);
     for (int32_t i = 0; i < req_num; ++i) {
       auto idx = dist(engine);


### PR DESCRIPTION
This change makes unseeded CPU random-neighbor sampling **28.4x faster** and
reduces mean call latency by **96.5%** in a same-host, same-toolchain A/B against
Alibaba `main`.

| Sampler latency | Alibaba `main` | This PR | Improvement |
| --- | ---: | ---: | ---: |
| Unseeded mean | 1,321.078 us/call | 46.593 us/call | 28.4x faster (96.5% lower) |
| Unseeded median | 1,294.023 us/call | 42.529 us/call | 30.4x faster (96.7% lower) |
| Seeded mean | 56.841 us/call | 41.946 us/call | 1.35x faster (26.2% lower) |
| Seeded median | 54.831 us/call | 40.581 us/call | 1.35x faster (26.0% lower) |

- Initialize each CPU random neighbor sampler's thread-local engine directly
  from `RandomSeedManager`.
- Avoid evaluating `getSeed()` after that thread-local engine has already been
  initialized.
- Apply the same behavior to sampling with and without edge IDs.

Source links:

- [Updated CPU random-neighbor sampler overloads](https://github.com/kmontemayor2-sc/graphlearn-for-pytorch/blob/21d5b3ee39987cd05f60a5661b3cf96089fd5dc5/graphlearn_torch/csrc/cpu/random_sampler.cc#L137-L176)
- [`RandomSeedManager::getSeed()` implementation](https://github.com/alibaba/graphlearn-for-pytorch/blob/88ff111ac0d9e45c6c9d2d18cfc5883dca07e9f9/graphlearn_torch/include/common.h#L36-L55)
- [Complete source diff](https://github.com/kmontemayor2-sc/graphlearn-for-pytorch/commit/21d5b3ee39987cd05f60a5661b3cf96089fd5dc5)

## Why

The [current sampler implementation](https://github.com/alibaba/graphlearn-for-pytorch/blob/88ff111ac0d9e45c6c9d2d18cfc5883dca07e9f9/graphlearn_torch/csrc/cpu/random_sampler.cc#L137-L176)
assigns `getSeed()` to an automatic local variable before declaring the
thread-local engine. That automatic initializer runs on every `UniformSample`
call. When no seed is configured, `getSeed()` constructs and reads
`std::random_device` each time, even though `std::mt19937` only uses the value
during its first initialization for that thread and overload.

Moving `getSeed()` into the `thread_local static` initializer preserves the
configured-seed behavior. In the unseeded case, it also preserves independent
entropy-derived engines while acquiring entropy only once per thread and
overload.

## Validation

- Built complete CPU-only native extensions from both Alibaba `main`
  (`88ff111a`) and this PR (`21d5b3ee`) with the same environment and
  `WITH_CUDA=OFF RELEASE=TRUE` settings.
- Ran each build in a fresh process with 10,000 nodes, degree 64, 256 input
  rows, fanout 10, 100 measured repetitions, and 17 Torch threads. The complete
  before/after results are reported in the summary table.
- Both modes passed neighbor-count, output-size, CSR-adjacency, and row-diversity
  checks.
- The seeded output matches the existing implementation's seeded benchmark
  output, confirming that configured-seed behavior is unchanged.
